### PR TITLE
Add back gradle-wrapper.properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .settings
 build
 gradle-*.properties
+!gradle-wrapper.properties
 
 src/main/ml-modules/base/root/runDuringDeployment/dataConstants/pipelineDataConstants.json
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists


### PR DESCRIPTION
It was accidentally excluded by the .gitignore