### PR TITLE
78: added forest properties to gradle.properties

### DIFF
--- a/docs/lux-backend-deployment.md
+++ b/docs/lux-backend-deployment.md
@@ -207,7 +207,9 @@ Most Gradle tasks communicate with MarkLogic.  As such, the commands running tho
 
 16. If you wish to determine whether the deployment kicked off a database indexing job, log into the admin console and check the database's status page.  As noted above, the [LUX backend search endpoint](/docs/lux-backend-api-usage.md#search) may return an error until all indexes it depends on become available.
 
-17. Load the content of the [/src/main/ml-data](/src/main/ml-data) directory, which includes deploying the thesauri. Should you encounter an issue, please see [Deploy Thesauri](#deploy-thesauri).
+17. **This step may be skipped.  Synonym support is disabled in LUX and the only content in the ml-data directory is the sample thesaurus.**
+
+    Load the content of the [/src/main/ml-data](/src/main/ml-data) directory, which includes deploying the thesauri. Should you encounter an issue, please see [Deploy Thesauri](#deploy-thesauri).
 
     `./gradlew mlLoadData -PenvironmentName=[env]`
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -141,6 +141,16 @@ tripleValueCacheTimeoutSeconds=86400
 fileLogLevel=debug
 keepLogFiles=30
 
+# Databases that are only to have one primary forest.
+mlDatabasesWithForestsOnOneHost=lux-modules
+# Default other databases to having one forest per host.
+mlContentForestsPerHost=1
+# Override the lux-content database to have three forests per host.
+mlForestsPerHost=lux-content,3
+# Replicate nearly all databases once, in order to keep any dependent app server and database online should one node go down.
+# Security is replicated twice to help if two nodes go down.
+mlDatabaseNamesAndReplicaCounts=lux-content,1,lux-modules,1,App-Services,1,Meters,1,Modules,1,Schemas,1,Triggers,1,Security,2
+
 # Configuration for the copyDatabase MCLP task
 copyDatabaseInputHost=10.5.157.118
 copyDatabaseInputPort=8000


### PR DESCRIPTION
Also documented deploying the sample thesaurus is not presently required.