### PR TITLE
#212: provides identical REST API options to tenant's second app server.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -343,6 +343,23 @@ task generateAdvancedSearchConfig (type: com.marklogic.gradle.task.MarkLogicTask
 }
 generateRemainingSearchTerms.finalizedBy generateAdvancedSearchConfig
 
+task copyRestApiOptions (type: com.marklogic.gradle.task.MarkLogicTask) {
+  doFirst {
+    println ""
+    println "Copying the REST API options to the second app server..."
+    println ""
+
+    def client = mlAppConfig.newDatabaseClient()
+    def script = new File('./build/buildSupport/copyRestApiOptions.sjs').getText('UTF-8')
+    def result = client.newServerEval().javascript(script).evalAs(String.class)
+
+    println ""
+    println result
+    println ""
+  }
+}
+generateAdvancedSearchConfig.finalizedBy copyRestApiOptions
+
 // Admin required to run this; thus piggybacking mlDeploySecurity.
 // More info in /docs/lux-backend-build-tool-and-tasks.md
 task setBanner(type: com.marklogic.gradle.task.ServerEvalTask) {

--- a/docs/lux-backend-build-tool-and-tasks.md
+++ b/docs/lux-backend-build-tool-and-tasks.md
@@ -17,6 +17,7 @@ This document describes Gradle tasks written for this project, which may be foun
 | `copyContentDatabaseConfGenerated` | **Deployment task** that provides populates a JavaScript-template with the database's configuration, thereby making it available to the runtime code. |  | 
 | `copyDatabase` | Developer convenience task that enables one to copy the data from one database to another, such as from a LUX shared environment to one's local environment. It uses MLCP. | See [Alternative 2: Copy a Database](/docs/lux-backend-import-data.md#alternative-2-copy-a-database) |
 | `copyPipelineDataConstants` | **Deployment task** responsible for making the data pipeline-provided data constants available to the backend's data constant generator.  It is configured to run before `mlLoadModules`. | See [Database Index Configuration](/config/README.md#database-index-configuration) and [Data Constants](/docs/lux-backend-data-constants.md) | 
+| `copyRestApiOptions` | **Deployment task** responsible for configuring the tenant's second application server with the same REST API options that are deployed by `mlLoadModules` for the tenant's first application server. See [/build.gradle](/build.gradle) for when this task will automatically run. |  |
 | `disableDeprecatedSSLProtocols` | Disable deprecated SSL protocols. |  |
 | `disableSSL` | Manual **deployment task** that disables SSL which then requires non-SSL connections on app serves. |  |
 | `enableSSL` | Manual **deployment task** that enables SSL which then requires SSL connections on app serves. |  |

--- a/scripts/buildSupport/copyRestApiOptions.sjs
+++ b/scripts/buildSupport/copyRestApiOptions.sjs
@@ -1,0 +1,40 @@
+const copyRestApiOptions = () => {
+  const sourceUris = [
+    '/Default/%%mlAppName%%-request-group-1/rest-api/options/lux-options.xml',
+    '/Default/%%mlAppName%%-request-group-1/rest-api/properties.xml',
+  ];
+
+  const messages = [];
+  sourceUris.forEach((sourceUri) => {
+    if (fn.docAvailable(sourceUri)) {
+      const targetUri = sourceUri.replace('group-1', 'group-2');
+      if (sourceUri == targetUri) {
+        fn.error(
+          xs.QName('DEPLOYMENT_ERROR'),
+          `Source and target URIs are the same: '${sourceUri}'`
+        );
+      }
+
+      xdmp.documentInsert(
+        targetUri,
+        fn.head(cts.doc(sourceUri)),
+        xdmp.documentGetPermissions(sourceUri),
+        xdmp.documentGetCollections(sourceUri)
+      );
+
+      messages.push(`Copied '${sourceUri}' to '${targetUri}'`);
+    } else {
+      fn.error(
+        xs.QName('DEPLOYMENT_ERROR'),
+        `Unable to copy '${sourceUri}' as it does not exist.`
+      );
+    }
+  });
+
+  return messages.join('\n');
+};
+
+xdmp.invokeFunction(copyRestApiOptions, {
+  database: xdmp.database('%%tenantModulesDatabase%%'),
+  update: 'true',
+});


### PR DESCRIPTION
Introduced the `copyRestApiOptions` Gradle task and wired to automatically run after `generateAdvancedSearchConfig`.