### PR TITLE
#149: documented how to remove a tenant

### DIFF
--- a/docs/lux-backend-deployment.md
+++ b/docs/lux-backend-deployment.md
@@ -16,7 +16,7 @@ In this document:
 - [Regenerate Advanced Search Configuration](#regenerate-advanced-search-configuration)
 - [Deploy Database Configuration Changes](#deploy-database-configuration-changes)
 - [Deploy Thesauri](#deploy-thesauri)
-- [Remove the Project](#remove-the-project)
+- [Remove a Tenant or Project](#remove-a-tenant-or-project)
 - [LUX MarkLogic Application Servers](#lux-marklogic-application-servers)
 - [Trace Events](#trace-events)
   - [Custom Trace Events](#custom-trace-events)
@@ -95,7 +95,7 @@ The current tenant deployment model includes shared configuration and does not i
         * [/src/main/ml-config/base/servers/admin-server.json](/src/main/ml-config/base/servers/admin-server.json)
         * [/src/main/ml-config/base/servers/app-services-server.json](/src/main/ml-config/base/servers/app-services-server.json)
         * [/src/main/ml-config/base/servers/manage-server.json](/src/main/ml-config/base/servers/manage-server.json)
-        * LUX does not present override HealthCheck application server settings.
+        * LUX does not presently override HealthCheck application server settings.
     * The certificate used by the above application servers, "built-in-app-cert".
     * The certificate used by all tenant application servers, "lux-app-cert".
     * The default group: [/src/main/ml-config/base/groups/default-group.json](/src/main/ml-config/base/groups/default-group.json)
@@ -240,7 +240,7 @@ Most Gradle tasks communicate with MarkLogic Server.  As such, the commands runn
 
     `./gradlew performBaseDeployment -i -PenvironmentName=[name]`
 
-    This is a convenience task that runs several others.  When it fails, the tasks before the specific one that failed would have completed successfully.  We have noted a couple scenarios when this task has failed partway through.  One is a timeout was exceeded; to get around that, temporarily increase the default time out on the Manage app server (port 8002).  The other was when the target environment was still creating an index required by a different subtask.  For example, `generateDataConstants` requires the `languageIdentifier` index.  It may be necessary to wait for the re-indexing job to complete before moving on; however, with this particular example (and possibly only instance), one could manually any other parts of `performBaseDeployment` and double back for `generateDataConstants` after re-indexing is complete.
+    This is a convenience task that runs several others.  When it fails, the tasks before the specific one that failed would have completed successfully.  We have noted a couple scenarios when this task has failed partway through.  One is a timeout was exceeded; to get around that, temporarily increase the default time out on the Manage app server (port 8002).  The other was when the target environment was still creating an index required by a different subtask.  For example, `generateDataConstants` requires the `languageIdentifier` index.  It may be necessary to wait for the re-indexing job to complete before moving on; however, with this particular example (and possibly only instance), one could manually run other subtasks of `performBaseDeployment` and double back for `generateDataConstants` after re-indexing is complete.
 
     The entire `performBaseDeployment` task and sub-tasks is expected to take about 6 minutes.
 
@@ -347,13 +347,52 @@ To load the thesauri and anything else in the [/src/main/ml-data](/src/main/ml-d
 
 `./gradlew mlLoadData -PenvironmentName=[name]`
 
-# Remove the Project
+# Remove a Tenant or Project
 
 ML Gradle includes the `mlUndeploy` task.  It should be used with great care in any environment you care about **--especially multi-tenant environments!**
 
 This task is **restricted to administrators**.  We did not develop the opposite of the `performBaseDeployment` task, even though the [%%mlAppName%%-deployer](/src/main/ml-config/base/security/roles/5-tenant-deployer-role.json) role should have the permissions required to undeploy non-security portions of the MarkLogic configuration.
 
-Please see the [ML Gradle wiki pages](https://github.com/marklogic-community/ml-gradle/wiki) for directions.
+**Delete these files** when removing one tenant from a multi-tenant environment:
+
+1. [/src/main/ml-config/base/security/roles/1a-base-reader-role.json](/src/main/ml-config/base/security/roles/1a-base-reader-role.json)
+2. [/src/main/ml-config/base/security/roles/2a-base-endpoint-consumer-role.json](/src/main/ml-config/base/security/roles/2a-base-endpoint-consumer-role.json)
+
+ML Gradle prevents projects from deleting specific databases, application servers, roles, and users, as well as all groups.  Protected app servers include Admin, App-Services, and Manage.  As such, it is not necessary to delete the ML Gradle configuration files for groups or those application servers.
+
+Within `gradle-[name].properties`, check the following property values.  **Triple-check for multi-tenant environments.**
+
+1. `mlAppName`
+2. `mlRestPortGroup1`
+3. `mlRestPortGroup2`
+4. `mlXdbcPort`
+5. `tenantContentDatabase`
+6. `tenantModulesDatabase`
+7. `mlDatabasesWithForestsOnOneHost`
+8. `mlForestsPerHost`
+9. If set, ensure `mlDatabaseNamesAndReplicaCounts` only includes the to-be-removed tenant's databases.
+
+Execute the following, specifying the same Gradle properties file.  Don't be too quick to hit the enter key.  There is no undo.
+
+`./gradlew mlUndeploy -i -Pconfirm=true -PenvironmentName=[name]`
+
+From within the MarkLogic admin console, delete the tenant's user/service accounts.
+
+At this point, the following resources should have been deleted:
+
+1. Tenant's content and modules databases.
+2. Tenant's content and modules forests.
+3. Tenant's application servers.
+4. Tenant's security roles.
+5. Tenant's user/service accounts.
+
+Verify the following did not change:
+
+1. The `base-reader` and `base-endpoint-consumer` roles.
+
+For multi-tenant deployments, smoke test a remaining tenant's application.
+
+If the tenant has a frontend and middle tier, decide whether those too should be removed.
 
 # LUX MarkLogic Application Servers
 


### PR DESCRIPTION
See the "Remove a Tenant or Project" section within lux-backend-deployment.md.

@clarkepeterf, the base roles were a bad idea.  I plan to remove them (#227) and update this documentation accordingly.

