### PR TITLE
#236: expanded scope to all invalid search requests and the search will match context

### DIFF
--- a/src/main/ml-modules/root/customErrorHandler.mjs
+++ b/src/main/ml-modules/root/customErrorHandler.mjs
@@ -79,6 +79,12 @@ function getJSErrorResponseBody(errorBody) {
       status = 'Internal Server Error';
       messageCode = 'InternalServerError';
       break;
+    // Convert to a bad request.
+    case 'InvalidSearchRequestError':
+      statusCode = 400;
+      status = 'Bad Request';
+      messageCode = 'BadRequestError';
+      break;
     case 'NotFoundError':
       statusCode = 404;
       status = 'Not Found';

--- a/src/main/ml-modules/root/lib/mlErrorsLib.mjs
+++ b/src/main/ml-modules/root/lib/mlErrorsLib.mjs
@@ -4,11 +4,15 @@
  * class name to determine the response's status code and status message.  Only the class name and
  * message reach the error handler.
  */
+// Helps non-search endpoints decide whether to log they failed.
+const INVALID_SEARCH_REQUEST_LABEL = 'Invalid search request';
+
 class BadRequestError extends Error {
   constructor(message) {
     super(message);
   }
 }
+
 class DataMergeError extends Error {
   constructor(message) {
     super(message);
@@ -21,6 +25,11 @@ class InternalServerError extends Error {
   }
 }
 
+class InvalidSearchRequestError extends Error {
+  constructor(message) {
+    super(`${INVALID_SEARCH_REQUEST_LABEL}: ${message}`);
+  }
+}
 class NotFoundError extends Error {
   constructor(message) {
     super(message);
@@ -33,10 +42,17 @@ class NotImplementedError extends Error {
   }
 }
 
+// Because e.name isn't InvalidSearchRequestError within a catch block :(
+function isInvalidSearchRequestError(e) {
+  return e.message && e.message.includes(INVALID_SEARCH_REQUEST_LABEL);
+}
+
 export {
   BadRequestError,
   DataMergeError,
   InternalServerError,
+  InvalidSearchRequestError,
   NotFoundError,
   NotImplementedError,
+  isInvalidSearchRequestError,
 };

--- a/src/main/ml-modules/root/lib/searchPatternsLib.mjs
+++ b/src/main/ml-modules/root/lib/searchPatternsLib.mjs
@@ -15,7 +15,10 @@ import {
   SEARCH_OPTIONS_NAME_EXACT,
   SEARCH_OPTIONS_NAME_KEYWORD,
 } from './appConstants.mjs';
-import { BadRequestError, InternalServerError } from './mlErrorsLib.mjs';
+import {
+  InternalServerError,
+  InvalidSearchRequestError,
+} from './mlErrorsLib.mjs';
 import { getRelatedListQuery } from './relatedListsLib.mjs';
 import { getSimilarQuery } from './similarLib.mjs';
 import {
@@ -219,8 +222,8 @@ SEARCH_PATTERN_CONFIG[PATTERN_NAME_DATE_RANGE] = {
     const startDateStr = dates[0].length > 0 ? dates[0] : null;
     const endDateStr = dates[1].length > 0 ? dates[1] : null;
     if (!startDateStr && !endDateStr) {
-      throw new BadRequestError(
-        `The '${termName} search term requires at least one date, such as '1800;1810', '1800', '1800;', or ';1810' (end of date range only).`
+      throw new InvalidSearchRequestError(
+        `the '${termName} search term requires at least one date, such as '1800;1810', '1800', '1800;', or ';1810' (end of date range only).`
       );
     }
 
@@ -676,8 +679,8 @@ function _formattedPatternResponse(
 
 function _requireRangeOperator(termName, op) {
   if (!['>', '>=', '<', '<=', '=', '!='].includes(op)) {
-    throw new BadRequestError(
-      `The '${termName}' search term requires the '_comp' property set to '>', '>=', '<', '<=', '=', or '!='.`
+    throw new InvalidSearchRequestError(
+      `the '${termName}' search term requires the '_comp' property set to '>', '>=', '<', '<=', '=', or '!='.`
     );
   }
 }

--- a/src/main/ml-modules/root/lib/similarLib.mjs
+++ b/src/main/ml-modules/root/lib/similarLib.mjs
@@ -1,7 +1,7 @@
 import { processSearchCriteria } from './searchLib.mjs';
 import {
-  BadRequestError,
   InternalServerError,
+  InvalidSearchRequestError,
   NotFoundError,
 } from './mlErrorsLib.mjs';
 import {
@@ -44,7 +44,7 @@ function getSimilarQuery(
 
 function getSimilarValues(scopeName, iri, aspects) {
   if (!SIMILAR_CONFIG.hasOwnProperty(scopeName)) {
-    throw new BadRequestError(
+    throw new InvalidSearchRequestError(
       `'${scopeName}' is not a valid search scope for similar queries`
     );
   }
@@ -53,8 +53,8 @@ function getSimilarValues(scopeName, iri, aspects) {
     throw new NotFoundError(`Document '${iri}' does not exist`);
   }
   if (!doesSearchScopeHaveType(scopeName, getType(doc))) {
-    throw new BadRequestError(
-      `Document '${iri}' is not associated with '${scopeName}' search scope`
+    throw new InvalidSearchRequestError(
+      `document '${iri}' is not associated with '${scopeName}' search scope`
     );
   }
   const returnObj = {};
@@ -72,7 +72,7 @@ function getSimilarValues(scopeName, iri, aspects) {
 
   for (const aspect of aspects) {
     if (!scopeConfig.hasOwnProperty(aspect)) {
-      throw new BadRequestError(
+      throw new InvalidSearchRequestError(
         `'${aspect}' is not a valid search aspect for the '${scopeName}' search scope. Valid similarity aspects for the '${scopeName}' search scope are: ${Object.keys(
           scopeConfig
         ).join(', ')}.`
@@ -136,8 +136,8 @@ function buildSearchCriteria(scope, similarValues) {
     }
   }
   if (criteriaCnt === 0) {
-    throw new BadRequestError(
-      `The similar query cannot extract any search criteria with the given aspects. Please select more aspects. If all aspects are selected, there is not enough information in this record to search for similar ones.`
+    throw new InvalidSearchRequestError(
+      `the similar query cannot extract any search criteria with the given aspects. Please select more aspects. If all aspects are selected, there is not enough information in this record to search for similar ones.`
     );
   }
   return combinedCriteria;


### PR DESCRIPTION
Introduced the InvalidSearchRequestError, which adds "Invalid search request" to the given message.  Changed many instances of BadRequestError to InvalidSearchRequestError.  Updated the facet and search estimate contexts to use isInvalidSearchRequestError to differentiate logging.  Search will match now also logs differently when the reason for failure is an invalid search request.