### PR TITLE
#273: phrases sent via JSON search grammar now always honored

### DIFF
--- a/src/main/ml-modules/root/lib/SearchCriteriaProcessor.mjs
+++ b/src/main/ml-modules/root/lib/SearchCriteriaProcessor.mjs
@@ -498,6 +498,9 @@ const SearchCriteriaProcessor = class {
             searchTerm.getPropertyNames().forEach((name) => {
               criterion[`_${name}`] = searchTerm.getProperty(name);
             });
+            // #273: Mark as a complete term to avoid tokenizing phrases when the
+            // encapsulating AND gets processed.
+            criterion._complete = true;
             return criterion;
           }),
         });


### PR DESCRIPTION
Needed to mark terms created from tokenization as complete terms, such that they would not be subsequently re-tokenized.