### PR TITLE
Corrected #273's original implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All changes to the MarkLogic (backend) portion of LUX capable of impacting the r
  
 ### Fixed
 
+- Fixed tokenization issue that [#273](https://github.com/project-lux/lux-marklogic/issues/273)'s original implementation introduced in v1.23.0.
+
 ### Security
 
 ## v1.23.2 - 2024-08-21

--- a/src/main/ml-modules/root/lib/SearchCriteriaProcessor.mjs
+++ b/src/main/ml-modules/root/lib/SearchCriteriaProcessor.mjs
@@ -489,7 +489,7 @@ const SearchCriteriaProcessor = class {
     if (utils.isString(termValue)) {
       const tokenizedValues = SearchCriteriaProcessor._tokenizeSearchTermValue(
         searchCriteria[termName],
-        searchTerm.isCompleteMatch()
+        searchTerm.isCompleteMatch() || searchTerm.isTokenized()
       );
       if (tokenizedValues.length > 1) {
         return searchTerm.addModifiedCriteria({
@@ -500,9 +500,8 @@ const SearchCriteriaProcessor = class {
             searchTerm.getPropertyNames().forEach((name) => {
               criterion[`_${name}`] = searchTerm.getProperty(name);
             });
-            // #273: Mark as a complete term to avoid tokenizing phrases when the
-            // encapsulating AND gets processed.
-            criterion._complete = true;
+            // #273: Prevent re-tokenization when the encapsulating AND gets processed.
+            criterion._tokenized = true;
             return criterion;
           }),
         });
@@ -772,9 +771,9 @@ const SearchCriteriaProcessor = class {
     return this.translateStringGrammarToJSON(scopeName, searchCriteria);
   }
 
-  static _tokenizeSearchTermValue(value, isCompleteMatch) {
-    // Do not tokenize or even trim when instructed to match on the full property value.
-    if (isCompleteMatch) {
+  static _tokenizeSearchTermValue(value, leaveAsIs) {
+    // Just return the value in an array when told not to manipulate the value.
+    if (leaveAsIs) {
       return [value];
     }
 

--- a/src/main/ml-modules/root/lib/SearchTerm.mjs
+++ b/src/main/ml-modules/root/lib/SearchTerm.mjs
@@ -157,6 +157,17 @@ const SearchTerm = class {
     return this.props.complete === true;
   }
 
+  addTokenized(tokenized) {
+    this.setTokenized(tokenized);
+    return this;
+  }
+  setTokenized(tokenized) {
+    this.props.tokenized = tokenized;
+  }
+  isTokenized() {
+    return this.props.tokenized === true;
+  }
+
   addValue(value) {
     this.setValue(value);
     return this;


### PR DESCRIPTION
#273: switched from "_complete" to new "_tokenized" search term property as _complete correctly uses a CTS value vs word query --but in this case we still want a word query just no additional tokenization.