### PR TITLE
309 - Updated triples used by search terms so that there are not over…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All changes to the MarkLogic (backend) portion of LUX capable of impacting the r
  
 ### Fixed
 
+- Updated triples used by search terms so that there are not overlapping triples used for different search scopes. This prevents records of the wrong scope showing up in related lists. (e.g. the Exhibitions concept showing up in Related People & Groups for Pablo Picasso) ([#309](https://github.com/project-lux/lux-marklogic/issues/309))
+
 ### Security
 
 - Added reader roles for ILS, IPCH, and PMC. Added reader roles for a couple other values that may be present in the `admin.sources` array: 'create' and 'update'. Added endpoint consumer role for IPCH. Removed endpoint consumer roles for YCBA and YUAG. [#280](https://github.com/project-lux/lux-marklogic/issues/280)

--- a/src/main/ml-modules/root/config/searchTermsConfig.mjs
+++ b/src/main/ml-modules/root/config/searchTermsConfig.mjs
@@ -130,7 +130,7 @@ const SEARCH_TERMS_CONFIG = {
     id: { patternName: 'documentId' },
     influencedByAgent: {
       patternName: 'hopWithField',
-      predicates: ['lux("influenced_by_agent")'],
+      predicates: ['lux("agentInfluencedCreation")'],
       targetScope: 'agent',
       hopInverseName: 'influenced',
       indexReferences: ['agentPrimaryName'],
@@ -138,7 +138,7 @@ const SEARCH_TERMS_CONFIG = {
     },
     influencedByConcept: {
       patternName: 'hopWithField',
-      predicates: ['lux("influenced_by_concept")'],
+      predicates: ['lux("conceptInfluencedCreation")'],
       targetScope: 'concept',
       hopInverseName: 'influenced',
       indexReferences: ['conceptPrimaryName'],
@@ -146,7 +146,7 @@ const SEARCH_TERMS_CONFIG = {
     },
     influencedByEvent: {
       patternName: 'hopWithField',
-      predicates: ['lux("influenced_by_activity")'],
+      predicates: ['lux("activityInfluencedCreation")'],
       targetScope: 'event',
       hopInverseName: 'influenced',
       indexReferences: ['eventPrimaryName'],
@@ -154,7 +154,7 @@ const SEARCH_TERMS_CONFIG = {
     },
     influencedByPlace: {
       patternName: 'hopWithField',
-      predicates: ['lux("influenced_by_place")'],
+      predicates: ['lux("placeInfluencedCreation")'],
       targetScope: 'place',
       hopInverseName: 'influenced',
       indexReferences: ['placePrimaryName'],


### PR DESCRIPTION
…lapping triples used for different search scopes. This prevents records of the wrong scope showing up in related lists. (e.g. the Exhibitions concept showing up in Related People & Groups for Pablo Picasso)