### PR TITLE
Updates for multiple issues:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ All changes to the MarkLogic (backend) portion of LUX capable of impacting the r
 
 ### Added
 
+- Enabled searching for Works whose creation was caused by an Event and vice-versa ([#269](https://github.com/project-lux/lux-marklogic/issues/269)).
+
 ### Changed
+
+- Updated Work Is Online facet to include Sets  ([#250](https://github.com/project-lux/lux-marklogic/issues/250)).
+
+- Change Work Created By to include People & Groups that are listed as being creators in part ([#278](https://github.com/project-lux/lux-marklogic/issues/278)).
+
+- Update AAT for archive sorting - used to be sort titles (http://vocab.getty.edu/aat/300451544), now it is sort values (http://vocab.getty.edu/aat/300456575) ([#325](https://github.com/project-lux/lux-marklogic/issues/325)).
 
 ### Removed
 

--- a/config/contentDatabaseConfGenerated.json
+++ b/config/contentDatabaseConfGenerated.json
@@ -561,7 +561,7 @@
       "field-name": "itemArchiveSortId",
       "field-path": [
         {
-          "path": "/json[type = ('HumanMadeObject', 'DigitalObject')]/identified_by[./classified_as/equivalent/id='http://vocab.getty.edu/aat/300451544']/content",
+          "path": "/json[type = ('HumanMadeObject', 'DigitalObject')]/identified_by[./classified_as/equivalent/id='http://vocab.getty.edu/aat/300456575']/content",
           "weight": 1
         }
       ],
@@ -933,7 +933,7 @@
       "field-name": "workArchiveSortId",
       "field-path": [
         {
-          "path": "/json[type = 'Set']/identified_by[./classified_as/equivalent/id='http://vocab.getty.edu/aat/300451544']/content",
+          "path": "/json[type = 'Set']/identified_by[./classified_as/equivalent/id='http://vocab.getty.edu/aat/300456575']/content",
           "weight": 1
         }
       ],
@@ -982,6 +982,10 @@
       "field-path": [
         {
           "path": "/indexedProperties[dataType = ('VisualItem', 'LinguisticObject')]/isOnline",
+          "weight": 1
+        },
+        {
+          "path": "/indexedProperties[dataType = 'Set']/isOnline",
           "weight": 1
         }
       ],
@@ -1352,6 +1356,10 @@
         },
         {
           "path": "/json[type='Set'][classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']/created_by/carried_out_by/id",
+          "weight": 1
+        },
+        {
+          "path": "/json[type='Set'][classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']/created_by/part/carried_out_by/id",
           "weight": 1
         }
       ],

--- a/scripts/generateIndexConf/input.tsv
+++ b/scripts/generateIndexConf/input.tsv
@@ -55,7 +55,7 @@ agent	HasDigitalImage	Boolean	numbers	agentHasDigitalImageBoolean	Search	Non	N		
 agent	ProfessionalActivity	Id	uri	agentProfessionalActivityId	RecordLink	Non	N		/json/carried_out/classified_as[not(./equivalent/id='http://vocab.getty.edu/aat/300393177')]/id	
 agent	ProfessionalActivity	Name	keyword	agentProfessionalActivityName	Search	Semantic	N			lux:agentProfessionallyActive
 										
-item	ArchiveSort	Id	string	itemArchiveSortId	Search	Non	N		/json[type = ('HumanMadeObject', 'DigitalObject')]/identified_by[./classified_as/equivalent/id='http://vocab.getty.edu/aat/300451544']/content	
+item	ArchiveSort	Id	string	itemArchiveSortId	Search	Non	N		/json[type = ('HumanMadeObject', 'DigitalObject')]/identified_by[./classified_as/equivalent/id='http://vocab.getty.edu/aat/300456575']/content	
 item	DataType	Name	keyword	itemDataTypeName	Search	Non	Y		/indexedProperties[dataType = ('HumanMadeObject', 'DigitalObject')]/dataType	
 item	HasDigitalImage	Boolean	numbers	itemHasDigitalImageBoolean	Search	Non	N		/indexedProperties[dataType = ('HumanMadeObject', 'DigitalObject')]/hasDigitalImage	
 item	IsOnline	Boolean	numbers	itemIsOnlineBoolean	Search	Non	N		/indexedProperties[dataType = ('HumanMadeObject', 'DigitalObject')]/isOnline	
@@ -96,10 +96,10 @@ item	MemberOf	Name	keyword	itemMemberOfName	Search	Semantic	N			la:member_of
 										
 	isCollectionItem	Boolean	numbers	isCollectionItemBoolean	Search	Non	N		/indexedProperties[dataType = ('HumanMadeObject', 'DigitalObject', 'VisualItem', 'LinguisticObject')]/isCollectionItem	
 										
-work	ArchiveSort	Id	string	workArchiveSortId	Search	Non	N		/json[type = 'Set']/identified_by[./classified_as/equivalent/id='http://vocab.getty.edu/aat/300451544']/content	
+work	ArchiveSort	Id	string	workArchiveSortId	Search	Non	N		/json[type = 'Set']/identified_by[./classified_as/equivalent/id='http://vocab.getty.edu/aat/300456575']/content	
 work	DataType	Name	keyword	workDataTypeName	Search	Non	Y		/indexedProperties[dataType = ('VisualItem', 'LinguisticObject')]/dataType ,  /indexedProperties[dataType = 'Set']/dataType	
 work	HasDigitalImage	Boolean	numbers	workHasDigitalImageBoolean	Search	Non	N		/indexedProperties[dataType = ('VisualItem', 'LinguisticObject')]/hasDigitalImage ,  /indexedProperties[dataType = 'Set']/hasDigitalImage	
-work	IsOnline	Boolean	numbers	workIsOnlineBoolean	Search	Non	N		/indexedProperties[dataType = ('VisualItem', 'LinguisticObject')]/isOnline	
+work	IsOnline	Boolean	numbers	workIsOnlineBoolean	Search	Non	N		/indexedProperties[dataType = ('VisualItem', 'LinguisticObject')]/isOnline , /indexedProperties[dataType = 'Set']/isOnline	
 work	IsPublicDomain	Boolean	numbers	workIsPublicDomainBoolean	Search	Non	N		/indexedProperties[dataType = ('VisualItem', 'LinguisticObject')]/isPublicDomain	
 work	Any	Text	keyword	workAnyText	Search	Non	N		/json[type = ('VisualItem', 'LinguisticObject')]//content ,  /json[type='Set'][./classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']//content	
 work		Name	keyword	workName	Search	Non	N		/json[type = ('VisualItem', 'LinguisticObject')]/identified_by[./type='Name']/content ,  /json[type='Set'][./classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']/identified_by[./type='Name']/content	
@@ -130,7 +130,7 @@ work	CreationStart	Date	datesAsLong	workCreationStartDateLong	Search	Non	N		/jso
 work	CreationEnd	Date	datesAsLong	workCreationEndDateLong	Search	Non	N		/json[type = ('VisualItem', 'LinguisticObject')]/created_by/timespan/_seconds_since_epoch_end_of_the_end ,  /json[type='Set'][classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']/created_by/timespan/_seconds_since_epoch_end_of_the_end	
 work	CreationPlace	Id	uri	workCreationPlaceId	RecordLink	Non	N		/json[type = ('VisualItem', 'LinguisticObject')]/created_by/took_place_at/id ,  /json[type='Set'][classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']/created_by/took_place_at/id	
 work	CreationPlace	Name	keyword	workCreationPlaceName	Search	Semantic	N			lux:placeOfCreation
-work	CreationAgent	Id	uri	workCreationAgentId	RecordLink	Non	N		/json[type = ('VisualItem', 'LinguisticObject')]/created_by/carried_out_by/id ,  /json[type = ('VisualItem', 'LinguisticObject')]/created_by/part/carried_out_by/id ,  /json[type='Set'][classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']/created_by/carried_out_by/id	
+work	CreationAgent	Id	uri	workCreationAgentId	RecordLink	Non	N		/json[type = ('VisualItem', 'LinguisticObject')]/created_by/carried_out_by/id ,  /json[type = ('VisualItem', 'LinguisticObject')]/created_by/part/carried_out_by/id ,  /json[type='Set'][classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']/created_by/carried_out_by/id , /json[type='Set'][classified_as/equivalent/id='http://vocab.getty.edu/aat/300375748']/created_by/part/carried_out_by/id	
 work	CreationAgent	Name	keyword	workCreationAgentName	Search	Semantic	N			lux:agentOfCreation
 work	MemberOf	Name	keyword	workMemberOfName	Search	Semantic	N	This should probably be merged into workPartOfName like workPartOfId		la:member_of
 										

--- a/src/main/ml-modules/root/config/searchTermsConfig.mjs
+++ b/src/main/ml-modules/root/config/searchTermsConfig.mjs
@@ -506,6 +506,13 @@ const SEARCH_TERMS_CONFIG = {
       hopInverseName: 'created',
       indexReferences: ['agentPrimaryName'],
     },
+    creationCausedBy: {
+      patternName: 'hopWithField',
+      predicates: ['lux("causeOfCreation")'],
+      targetScope: 'event',
+      hopInverseName: 'causedCreationOf',
+      indexReferences: ['workCreationAgentId'],
+    },
     creationInfluencedBy: {
       patternName: 'hopWithField',
       predicates: ['lux("agentInfluencedCreation")'],


### PR DESCRIPTION
- #250: Updated Work Is Online facet to include Sets
- #269: Enabled searching for Works whose creation was caused by an Event and vice-versa
- #278: Change Work Created By to include People & Groups that are listed as being creators in part
- #325: Update AAT for archive sorting - used to be sort titles (http://vocab.getty.edu/aat/300451544), now it is sort values (http://vocab.getty.edu/aat/300456575)