### PR TITLE
Revert "#337 - Workaround for missing 'setClassifiedAs' triple on Col…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ All changes to the MarkLogic (backend) portion of LUX capable of impacting the r
 - Change Work Created By to include People & Groups that are listed as being creators in part ([#278](https://github.com/project-lux/lux-marklogic/issues/278)).
 
 - Update AAT for archive sorting - used to be sort titles (http://vocab.getty.edu/aat/300451544), now it is sort values (http://vocab.getty.edu/aat/300456575) ([#325](https://github.com/project-lux/lux-marklogic/issues/325)).
+  
+- Revert workaround in #337 - triple has been restored ([#337](https://github.com/project-lux/lux-marklogic/issues/337)).
 
 ### Removed
 

--- a/src/main/ml-modules/root/config/searchTermsConfig.mjs
+++ b/src/main/ml-modules/root/config/searchTermsConfig.mjs
@@ -407,7 +407,7 @@ const SEARCH_TERMS_CONFIG = {
   set: {
     classification: {
       patternName: 'hopWithField',
-      predicates: ['lux("referenceClassifiedAs")'],
+      predicates: ['lux("setClassifiedAs")'],
       targetScope: 'concept',
       hopInverseName: 'classificationOfSet',
       indexReferences: ['conceptPrimaryName'],


### PR DESCRIPTION
…lection sets. Sets will use the triple 'referenceClassifiedAs' triple in the meantime"

This reverts commit 2c5fd196c011099567cfdfa79109053d3bbd6820.