### PR TITLE
Introductory version of comparePredicates.js and extended checkPredicates.js

### DIFF
--- a/scripts/checkPredicates.js
+++ b/scripts/checkPredicates.js
@@ -1,16 +1,22 @@
 /*
  * Get an estimated number of *documents* containing *at least* one triple by predicate where
- * the list of predicates come from the backend's search term configuration.
+ * the list of predicates come from the backend's search term and keyword search configurations.
  *
  * Purposes of the script include:
  *
  *   1. Find out if a search term is configured to non-existent triples.
  *   2. Find out if some triples are missing (by expected predicate).
  *   3. Find out if some search terms will never return results for some users.
+ *   4. Use as input into comparePredicates.js; see that script for this script's configuration.
  *
  * Note there are additional triples in the dataset, such as those with the crm('p2_has_type')
- * predicate.  Those are not included by this script.
+ * predicate.  Those are not included by this script.  One may use comparePredicates.js to
+ * draw those out.
  */
+import {
+  getSearchScopeNames,
+  getSearchScopePredicates,
+} from '/lib/searchScope';
 import { getSearchTermsConfig } from '/config/searchTermsConfig';
 import { START_OF_GENERATED_QUERY as prefixes } from '/lib/SearchCriteriaProcessor';
 import * as utils from '/utils/utils';
@@ -26,16 +32,30 @@ const includeCurrentUser = false;
 // Set justZeros to true when you only want to predicates with an estimate of zero.
 const justZeros = true;
 
+// When true, only the predicate names are returned, as an array.  This is helpful when using
+// this script's output as input to comparePredicates.js.
+const formatAsArrayOfPredicates = false;
+
 // Set identifyTerms to true to include the terms in the response (versus just the estimates).
-const identifyTerms = false;
+// Forced to false when formatAsArrayOfPredicates is true.
+let identifyTerms = false;
 
 /* * * END: Script configuration * * */
+
+// Conditionally override
+if (formatAsArrayOfPredicates) {
+  identifyTerms = false;
+}
 
 if (includeCurrentUser && !usernames.includes(xdmp.getCurrentUser())) {
   usernames.push(xdmp.getCurrentUser());
 }
 
 const searchTermsConfig = getSearchTermsConfig();
+
+const resolvePredicate = (predicate) => {
+  return xdmp.eval(`${prefixes}${predicate}`);
+};
 
 // Create a scopeName-termName object of terms with predicates.
 const termsWithPredicates = {};
@@ -50,42 +70,56 @@ Object.keys(searchTermsConfig).forEach((scopeName) => {
       termConfig.predicates.forEach((predicate) => {
         predicate = predicate.replace(allDoubleQuotesRegExp, "'"); // for readability
         termsWithPredicates[scopeName][termName].resolvedPredicates.push(
-          xdmp.eval(`${prefixes}${predicate}`)
+          resolvePredicate(predicate)
         );
       });
     }
   });
 });
 
+const checkPredicate = (findings, scopeName, termName, predicate) => {
+  const recordConfigOnly = findings[predicate];
+  if (recordConfigOnly) {
+    if (identifyTerms && termName != null) {
+      findings[predicate].terms.push(`${scopeName}.${termName}`);
+    }
+  } else {
+    const estimate = cts.estimate(
+      cts.jsonPropertyValueQuery('predicate', predicate)
+    );
+    if ((justZeros && estimate == 0) || !justZeros) {
+      if (identifyTerms && termName != null) {
+        findings[predicate] = {
+          estimate: estimate,
+          terms: [`${scopeName}.${termName}`],
+        };
+      } else {
+        findings[predicate] = estimate;
+      }
+    }
+  }
+};
+
 const checkPredicates = () => {
   const findings = {};
+
+  // Check all predicates configured to search terms.
   Object.keys(termsWithPredicates).forEach((scopeName) => {
     Object.keys(termsWithPredicates[scopeName]).forEach((termName) => {
       const termConfig = termsWithPredicates[scopeName][termName];
       termConfig.resolvedPredicates.forEach((predicate) => {
-        const recordConfigOnly = findings[predicate];
-        if (recordConfigOnly) {
-          if (identifyTerms) {
-            findings[predicate].terms.push(`${scopeName}.${termName}`);
-          }
-        } else {
-          const estimate = cts.estimate(
-            cts.jsonPropertyValueQuery('predicate', predicate)
-          );
-          if ((justZeros && estimate == 0) || !justZeros) {
-            if (identifyTerms) {
-              findings[predicate] = {
-                estimate: estimate,
-                terms: [`${scopeName}.${termName}`],
-              };
-            } else {
-              findings[predicate] = estimate;
-            }
-          }
-        }
+        checkPredicate(findings, scopeName, termName, predicate);
       });
     });
   });
+
+  // Add in predicates used by keyword search.
+  getSearchScopeNames().forEach((scopeName) => {
+    getSearchScopePredicates(scopeName).forEach((predicate) => {
+      checkPredicate(findings, scopeName, null, resolvePredicate(predicate));
+    });
+  });
+
   return utils.sortObj(findings);
 };
 
@@ -94,5 +128,10 @@ for (const username of usernames) {
   findings[username] = xdmp
     .invokeFunction(checkPredicates, { userId: xdmp.user(username) })
     .toArray()[0];
+}
+if (formatAsArrayOfPredicates) {
+  Object.keys(findings).forEach((username) => {
+    findings[username] = Object.keys(findings[username]).sort();
+  });
 }
 findings;

--- a/scripts/comparePredicates.js
+++ b/scripts/comparePredicates.js
@@ -1,0 +1,117 @@
+/*
+ * This script compares all predicates in the dataset to those configured by the backend
+ * in order to surface a) configured predicates that do not exist and b) predicates that
+ * exist but are not configured.  One of two arrays is calculated herein.  The other needs
+ * to be manually supplied using checkPredicates.js.
+ */
+'use strict';
+
+const dedup = true;
+
+// All predicates
+// The following query takes between 15 and 45 seconds.
+const op = require('/MarkLogic/optic');
+const s = op.col('s');
+const p = op.col('p');
+const o = op.col('o');
+let allPredicates = op
+  .fromTriples(op.pattern(s, p, o))
+  .groupBy(p)
+  .result()
+  .toArray()
+  .map((row) => {
+    return row.p + '';
+  })
+  .sort();
+// Already de-dup'd
+// if (dedup) {
+//   allPredicates = [...new Set(allPredicates)];
+// }
+
+// Configured predicates.
+//
+// The following list was compiled from the 2024-10-19 dataset using checkPredicates.js
+// configured as such:
+//
+// const usernames = ['admin'];
+// const includeCurrentUser = false;
+// const justZeros = false;
+// const formatAsArrayOfPredicates = true;
+// let identifyTerms = false;
+//
+let configuredPredicates = [
+  'http://www.cidoc-crm.org/cidoc-crm/P106i_forms_part_of',
+  'http://www.cidoc-crm.org/cidoc-crm/P107i_is_current_or_former_member_of',
+  'http://www.cidoc-crm.org/cidoc-crm/P16_used_specific_object',
+  'http://www.cidoc-crm.org/cidoc-crm/P45_consists_of',
+  'http://www.cidoc-crm.org/cidoc-crm/P72_has_language',
+  'http://www.cidoc-crm.org/cidoc-crm/P89_falls_within',
+  'http://www.w3.org/2004/02/skos/core#broader',
+  'https://linked.art/ns/terms/member_of',
+  'https://lux.collections.yale.edu/ns/about_or_depicts_agent',
+  'https://lux.collections.yale.edu/ns/about_or_depicts_concept',
+  'https://lux.collections.yale.edu/ns/about_or_depicts_object',
+  'https://lux.collections.yale.edu/ns/about_or_depicts_place',
+  'https://lux.collections.yale.edu/ns/about_or_depicts_work',
+  'https://lux.collections.yale.edu/ns/activityInfluencedCreation',
+  'https://lux.collections.yale.edu/ns/agentAny',
+  'https://lux.collections.yale.edu/ns/agentClassifiedAs',
+  'https://lux.collections.yale.edu/ns/agentGender',
+  'https://lux.collections.yale.edu/ns/agentInfluencedCreation',
+  'https://lux.collections.yale.edu/ns/agentInfluencedProduction',
+  'https://lux.collections.yale.edu/ns/agentNationality',
+  'https://lux.collections.yale.edu/ns/agentOccupation',
+  'https://lux.collections.yale.edu/ns/agentOfBeginning',
+  'https://lux.collections.yale.edu/ns/agentOfCreation',
+  'https://lux.collections.yale.edu/ns/agentOfCuration',
+  'https://lux.collections.yale.edu/ns/agentOfEncounter',
+  'https://lux.collections.yale.edu/ns/agentOfProduction',
+  'https://lux.collections.yale.edu/ns/agentOfPublication',
+  'https://lux.collections.yale.edu/ns/carries_or_shows',
+  'https://lux.collections.yale.edu/ns/causeOfCreation',
+  'https://lux.collections.yale.edu/ns/conceptAny',
+  'https://lux.collections.yale.edu/ns/conceptClassifiedAs',
+  'https://lux.collections.yale.edu/ns/conceptInfluencedCreation',
+  'https://lux.collections.yale.edu/ns/eventAny',
+  'https://lux.collections.yale.edu/ns/eventCarriedOutBy',
+  'https://lux.collections.yale.edu/ns/eventClassifiedAs',
+  'https://lux.collections.yale.edu/ns/eventTookPlaceAt',
+  'https://lux.collections.yale.edu/ns/itemAny',
+  'https://lux.collections.yale.edu/ns/itemClassifiedAs',
+  'https://lux.collections.yale.edu/ns/placeAny',
+  'https://lux.collections.yale.edu/ns/placeClassifiedAs',
+  'https://lux.collections.yale.edu/ns/placeInfluencedCreation',
+  'https://lux.collections.yale.edu/ns/placeOfActivity',
+  'https://lux.collections.yale.edu/ns/placeOfBeginning',
+  'https://lux.collections.yale.edu/ns/placeOfCreation',
+  'https://lux.collections.yale.edu/ns/placeOfEncounter',
+  'https://lux.collections.yale.edu/ns/placeOfEnding',
+  'https://lux.collections.yale.edu/ns/placeOfProduction',
+  'https://lux.collections.yale.edu/ns/placeOfPublication',
+  'https://lux.collections.yale.edu/ns/referenceAny',
+  'https://lux.collections.yale.edu/ns/referenceClassifiedAs',
+  'https://lux.collections.yale.edu/ns/setAny',
+  'https://lux.collections.yale.edu/ns/setClassifiedAs',
+  'https://lux.collections.yale.edu/ns/techniqueOfProduction',
+  'https://lux.collections.yale.edu/ns/typeOfProfessionalActivity',
+  'https://lux.collections.yale.edu/ns/workAny',
+  'https://lux.collections.yale.edu/ns/workClassifiedAs',
+];
+if (dedup) {
+  configuredPredicates = [...new Set(configuredPredicates)];
+}
+
+function getArrayDiff(configuredPredicates, allPredicates) {
+  const existsButNotReferenced = allPredicates.filter((item) => {
+    return !configuredPredicates.includes(item);
+  });
+  const referencedButDoesNotExist = configuredPredicates.filter((item) => {
+    return !allPredicates.includes(item);
+  });
+  return {
+    referencedButDoesNotExist,
+    existsButNotReferenced,
+  };
+}
+
+getArrayDiff(configuredPredicates, allPredicates);


### PR DESCRIPTION
checkPredicates.js now accounts for predicates configured to keyword search and may now be configured to format its results as input into comparePredicates.js.