### PR TITLE
#551: When restoring My Collections data, import as JSON (not binary)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,11 +7,11 @@
   "editor.defaultFormatter": "vscode.css-language-features",
   "prettier.singleQuote": true,
   "[json]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
-    "[javascript]": {
-      "editor.defaultFormatter": "esbenp.prettier-vscode"
-    },
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
   "files.associations": {
     "*.sjs": "javascript",
     "*.mjs": "javascript",
@@ -35,4 +35,7 @@
     "wildcarded",
     "xdmp"
   ],
+  "[xml]": {
+    "editor.defaultFormatter": "mikeburgh.xml-format"
   }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 # Changelog
 
 All changes to the MarkLogic (backend) portion of LUX capable of impacting the runtime experience will be documented in this file.  These are to include software, configuration, and environment changes.
-## v1.42.0 - 2025-06-30
+## v1.43.0 - 2025-07-14
 ### Added
-- Added TDEs to create triples for My Collections documents ([#503](https://github.com/project-lux/lux-marklogic/issues/503))
 
 ### Changed
 
@@ -12,9 +11,11 @@ All changes to the MarkLogic (backend) portion of LUX capable of impacting the r
 ### Fixed
 
 ### Security
+- In support of restoring the correct document permissions on My Collections data ([#551](https://github.com/project-lux/lux-marklogic/issues/551)), changed the [%%mlAppName%%-my-collections-data-updater role](/docs/lux-backend-security-and-software.md#my-collections-data-updater) to have the rest-reader and rest-writer privileges as opposed to the rest-writer role.
 
 ## v1.42.0 - 2025-06-30
 ### Added
+- Added TDEs to create triples for My Collections documents ([#503](https://github.com/project-lux/lux-marklogic/issues/503))
 
 ### Changed
 - The [Update Document endpoint](/docs/lux-backend-api-usage.md#update-document) now requires the `uri` parameter ([#546](https://github.com/project-lux/lux-marklogic/issues/546))

--- a/scripts/jobs/myCollections/backup/backup-options.txt
+++ b/scripts/jobs/myCollections/backup/backup-options.txt
@@ -7,3 +7,5 @@
 --s3-add-credentials
 --categories           "collections,permissions"
 --file-count           "1"
+# Needed for shared environments but not local developer environments.
+#--ssl-protocol         "TLSv1.2"

--- a/scripts/jobs/myCollections/delete/delete-options.txt
+++ b/scripts/jobs/myCollections/delete/delete-options.txt
@@ -4,3 +4,5 @@
 --auth-type            "DIGEST"
 --database             "lux-content"
 --username             ""
+# Needed for shared environments but not local developer environments.
+#--ssl-protocol         "TLSv1.2"

--- a/scripts/jobs/myCollections/restore/restore-options.txt
+++ b/scripts/jobs/myCollections/restore/restore-options.txt
@@ -6,5 +6,6 @@
 --username             ""
 --s3-add-credentials
 --uri-template         "{/json/id}"
-# MLE-22714: to be supported in Flux 1.4; until then, files without file extensions are loaded as binary files.
-#--document-type        "JSON"
+--document-type        "json"
+# Needed for shared environments but not local developer environments.
+#--ssl-protocol         "TLSv1.2"

--- a/scripts/jobs/myCollections/testing-notes.txt
+++ b/scripts/jobs/myCollections/testing-notes.txt
@@ -5,6 +5,12 @@ aws configure
 [enter info]
 
 cd /opt
+---
+NOTE: the following works for released versions of Flux.
+Until Flux 1.4 is released, we need to use a snapshot of the develop branch.
+One may be made by cloning Flux's repo, switch to the develop branch, and following these directions:
+https://github.com/marklogic/flux/blob/develop/CONTRIBUTING.md#building-the-distribution-locally
+---
 curl -L https://github.com/marklogic/flux/releases/download/1.3.0/marklogic-flux-1.3.0.zip > marklogic-flux-1.3.0.zip
 unzip marklogic-flux-1.3.0.zip
 export FLUX_HOME=/opt/marklogic-flux-1.3.0
@@ -24,6 +30,7 @@ sh [verb]-my-collections-data.sh [verb]-options.txt
 Validation:
   backup: If all went well, you can download the newly created zip, uncompress, and check the contents.
   restore: Between backup and restore, change a My Collection document in the database; after restore, see if the edit is gone.
+  delete: Check in query console to see if the prod or nonProd files were deleted (but not both for a single run).
 
 exit
 docker compose down

--- a/src/main/ml-config/base/security/roles/8-my-collections-data-updater-role.json
+++ b/src/main/ml-config/base/security/roles/8-my-collections-data-updater-role.json
@@ -1,8 +1,18 @@
 {
   "role-name": "%%mlAppName%%-my-collections-data-updater",
   "description": "CAUTION! This role may read, update, and delete any My Collections data and is to be used by the Blue/Green switch process and independent backups.",
-  "role": ["rest-writer"],
+  "role": [],
   "privilege": [
+    {
+      "privilege-name": "rest-reader",
+      "action": "http://marklogic.com/xdmp/privileges/rest-reader",
+      "kind": "execute"
+    },
+    {
+      "privilege-name": "rest-writer",
+      "action": "http://marklogic.com/xdmp/privileges/rest-writer",
+      "kind": "execute"
+    },
     {
       "privilege-name": "xdbc:eval",
       "action": "http://marklogic.com/xdmp/privileges/xdbc-eval",


### PR DESCRIPTION
Using a snapshot of Flux 1.4, proved out the ability to restore data as JSON (vs. binary). Also changed the data updater role from having the rest-writer role to the underlying privileges such that the rest-writer role's default permissions are not assigned to the restored documents.