### PR TITLE
#521: Get Tenant Status endpoint to include My Collection and user profile document estimates (not stats endpoint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All changes to the MarkLogic (backend) portion of LUX capable of impacting the r
 
 ### Changed
 - Changed from using the classification's equivalent ID to its primary ID when determining whether a record is a My Collection ([#558](https://github.com/project-lux/lux-marklogic/issues/558))
+- Moved the My Collection and user profile document estimates from the [Stats endpoint](/docs/lux-backend-api-usage.md#stats) to the [Get Tenant Status endpoint](/docs/lux-backend-api-usage.md#get). The estimates are only included when the requesting user has the `https://lux.collections.yale.edu/privileges/%%mlAppName%%-update-tenant-status` privilege which is presently only granted to the [%%mlAppName%%-deployer role](/docs/lux-backend-security-and-software.md#deployer). (Edit to [#521](https://github.com/project-lux/lux-marklogic/issues/521))
 
 ### Removed
   

--- a/docs/lux-backend-api-usage.md
+++ b/docs/lux-backend-api-usage.md
@@ -1561,11 +1561,9 @@ Response Body:
       "concept":4649130,
       "event":153318,
       "item":17545158,
-      "myCollection":1227,
       "place":579366,
       "reference":11031350,
       "set":305353,
-      "userProfile":911,
       "work":13560980
     }
   },
@@ -1671,7 +1669,7 @@ Response Body:
 
 ### Get
 
-The Get Tenant Status endpoint may be used to get information on a tenant, including its current role and whether it is accepting updates. User and service accounts may consume this endpoint.
+The Get Tenant Status endpoint may be used to get information on a tenant, including its current role and whether it is accepting updates. User and service accounts may consume this endpoint.  Users with the `https://lux.collections.yale.edu/%%mlAppName%%-update-tenant-status` execute privilege will also receive estimates for the numbers of My Collection and user profile documents.
 
 **URL** : `/ds/lux/tenantStatus/get.mjs`
 

--- a/src/main/ml-modules/root/ds/lux/stats.mjs
+++ b/src/main/ml-modules/root/ds/lux/stats.mjs
@@ -1,24 +1,14 @@
 import { handleRequest } from '../../lib/securityLib.mjs';
 import { getSearchScope, getSearchScopeNames } from '../../lib/searchScope.mjs';
 import { COLLECTION_NAME_MY_COLLECTIONS_FEATURE } from '../../lib/appConstants.mjs';
-import {
-  getMyCollectionDocumentCount,
-  getUserProfileDocumentCount,
-} from '../../lib/environmentLib.mjs';
-import { sortObj } from '../../utils/utils.mjs';
 
 const unitName = external.unitName;
 
 handleRequest(function () {
   const start = new Date();
-
-  const restrictByProductionMode = true;
   const doc = {
     estimates: {
-      searchScopes: {
-        myCollection: getMyCollectionDocumentCount(restrictByProductionMode),
-        userProfile: getUserProfileDocumentCount(restrictByProductionMode),
-      },
+      searchScopes: {},
     },
     metadata: {},
   };
@@ -35,8 +25,6 @@ handleRequest(function () {
       )
     );
   });
-
-  doc.estimates.searchScopes = sortObj(doc.estimates.searchScopes);
 
   const end = new Date();
   doc.metadata.timestamp = end;

--- a/src/main/ml-modules/root/lib/securityLib.mjs
+++ b/src/main/ml-modules/root/lib/securityLib.mjs
@@ -450,6 +450,13 @@ function requireUserMayUpdateTenantStatus() {
   xdmp.securityAssert(PRIVILEGE_NAME_UPDATE_TENANT_STATUS, 'execute');
 }
 
+function mayUpdateTenantStatus() {
+  return xdmp.passiveHasPrivilege(
+    PRIVILEGE_NAME_UPDATE_TENANT_STATUS,
+    'execute'
+  );
+}
+
 // Get an array of unit names known to this deployment.
 function getEndpointAccessUnitNames() {
   // In case the property is not set, in which there are no endpoint consumers with
@@ -551,6 +558,7 @@ export {
   handleRequestV2ForUnitTesting,
   isConfiguredForUnit,
   isCurrentUserServiceAccount,
+  mayUpdateTenantStatus,
   removeUnitConfigProperties,
   requireUserMayUpdateTenantStatus,
   throwIfCurrentUserIsServiceAccount,


### PR DESCRIPTION
Requesting user must have the `https://lux.collections.yale.edu/privileges/%%mlAppName%%-update-tenant-status` execute privilege for the additional info to be included.

The stats endpoint continues to exclude My Collection documents from the Set estimate and user profiles from the agent estimate.