### PR TITLE
#639: group and server dynamic host configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All changes to the MarkLogic (backend) portion of LUX capable of impacting the r
 
 ## v3.0.0 - Unreleased
 
-TODO: document all changes in PR
+TODO: document all changes in mini-mi-off-release-branch.
 
 ### Added
+
+- Added the [./src/main/ml-config/dynamic-host/](./src/main/ml-config/dynamic-host/) MarkLogic Gradle configuration directory as well as the `allowDynamicHosts` and `enableApiTokenAuthentication` Gradle properties.  The new configuration directory allows us to continue supporting MarkLogic 11 deployments.  The properties allow us to enable or disable the MarkLogic 12 dynamic host-related settings we do not plan to change when scaling out or in. Minimum supported ML 12 version is 12.0.1. ([#639](https://github.com/project-lux/lux-marklogic/issues/639))
 
 ### Changed
 

--- a/docs/lux-backend-security-and-software.md
+++ b/docs/lux-backend-security-and-software.md
@@ -199,9 +199,9 @@ For version compatibility questions, see the [MarkLogic Server Product Support M
 
 | Software | Version | Build Property | Notes |
 |----------|---------|----------------|-------|
-| [MarkLogic Server](https://developer.marklogic.com/products/marklogic-server) | 12.0.0 | n/a | | 
-| [MarkLogic AWS CloudFormation Template (CFT)](https://github.com/marklogic/cloud-enablement-aws/tree/11.0-master) | 12.0.0 | n/a | LUX uses a modified version, maintained in a private repo. |
-| [MarkLogic Content Pump (MLCP)](https://github.com/marklogic/marklogic-contentpump) | 12.0.0 | `mlcpVersion` | Loading content in MarkLogic. |
+| [MarkLogic Server](https://developer.marklogic.com/products/marklogic-server) | 12.0.1 | n/a | | 
+| [MarkLogic AWS CloudFormation Template (CFT)](https://github.com/marklogic/cloud-enablement-aws/tree/11.0-master) | 12.0.1 | n/a | LUX uses a modified version, maintained in a private repo. |
+| [MarkLogic Content Pump (MLCP)](https://github.com/marklogic/marklogic-contentpump) | 12.0.1 | `mlcpVersion` | Loading content in MarkLogic. |
 | [Flux](https://github.com/marklogic/flux) ([docs](https://marklogic.github.io/flux/)) | 1.4.0 | n/a | [Backup](/scripts/jobs/myCollections/backup), [restore](/scripts/jobs/myCollections/restore), and [delete](/scripts/jobs/myCollections/delete) My Collections jobs. |
 | [Gradle](https://github.com/gradle/gradle) | 8.13 | n/a | Post-CFT deployment. |
 | [MarkLogic Gradle Plugin](https://github.com/marklogic-community/ml-gradle) | 5.0.0 | `mlGradleVersion` | Post-CFT deployment. |

--- a/gradle.properties
+++ b/gradle.properties
@@ -40,6 +40,10 @@ identifierSetNoteLabel=https://todo.concept.display.name
 
 defaultCodeVersion=3.x
 
+# Dynamic host-related configuration.  Set both to true in blue and green.
+allowDynamicHosts=false
+enableApiTokenAuthentication=false
+
 # Ports
 mlAppServicesPort=8000
 mlDeployPort=8004
@@ -85,11 +89,14 @@ mlModulePaths=build/main/ml-modules,build/test/ml-modules
 #
 # build/main/ml-config/base-unsecured: Developer environments are to use this configuration.
 #
+# build/main/ml-config/dynamic-host: Include in ML 12 deployments.  Once we no longer support ML 11,
+# we can merge these settings into the base ml-config dir.
+#
 # build/main/ml-config/oauth: Tenants with the My Collections feature enabled.
 #
 # build/test/ml-config: Non-production environments only.
 # 
-mlConfigPaths=build/main/ml-config/base,build/main/ml-config/base-secured,build/test/ml-config
+mlConfigPaths=build/main/ml-config/base,build/main/ml-config/base-secured,build/main/ml-config/dynamic-host,build/test/ml-config
 
 # OAuth configuration, which is an alternative to this project's Digest authentication default.
 # These properties need only be set when build/main/ml-config/oauth is in mlConfigPaths.
@@ -161,7 +168,7 @@ backupBasePath=s3://OVERRIDE-S3-BACKUP-PATH
 # Versions referenced by build.gradle.
 mlGradleVersion=5.0.0
 mlUnitTestVersion=1.5.0
-mlcpVersion=12.0.0
+mlcpVersion=12.0.1
 orgJsonVersion=20220320
 orgApacheCommonsCsvVersion=1.5.1-marklogic
 netSalimonPropertiesVersion=1.5.2

--- a/src/main/ml-config/dynamic-host/groups/default-group.json
+++ b/src/main/ml-config/dynamic-host/groups/default-group.json
@@ -1,0 +1,4 @@
+{
+  "group-name": "Default",
+  "allow-dynamic-hosts": %%allowDynamicHosts%%
+}

--- a/src/main/ml-config/dynamic-host/servers/admin-server.json
+++ b/src/main/ml-config/dynamic-host/servers/admin-server.json
@@ -1,0 +1,4 @@
+{
+  "server-name": "Admin",
+  "API-token-authentication": %%enableApiTokenAuthentication%%
+}


### PR DESCRIPTION
#639: Introduced dynamic-host ml-config dir and associated props to continue to support ML 11 deployments (Graviton) and, for ML 12 environments, specify whether to enable or disable dynamic host-related properties we do not what to toggle when scaling out or in.  Upgraded to 12.0.1 as 12.0.0's PUT /manage/v2/groups/{id|name}/properties would not accept the allow-dynamic-hosts property.  Default configuration is for ML 12 with dynamic hosts disabled.