### PR TITLE
remove mlRestPort2 from gradle.properties - it was replaced by mlRest…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,6 @@ mlManagePort=8002
 mlRestPort=8003
 mlDeployPort=8004
 mlXdbcPort=8005
-mlRestPort2=8006
 # Do not enable by default.  See "Enabling Unit Testing" in lux-backend-deployment.md for details.
 #mlTestRestPort=8010
 


### PR DESCRIPTION
…PortGroup2