### PR TITLE
More CTS in Optic, including optimization 18

### DIFF
--- a/docs/lux-optic-primer.md
+++ b/docs/lux-optic-primer.md
@@ -87,6 +87,18 @@
   - [Optimization 17: Select barrier on nested sub-plans](#optimization-17-select-barrier-on-nested-sub-plans)
     - [Benchmark (MarkLogic 12.0.1)](#benchmark-marklogic-1201)
     - [Analysis](#analysis)
+  - [Optimization 18: CTS Estimate](#optimization-18-cts-estimate)
+    - [Problem](#problem)
+    - [When CTS Estimate applies](#when-cts-estimate-applies)
+    - [Pattern CTS Conversions](#pattern-cts-conversions)
+    - [Benchmark (MarkLogic 12.0.1)](#benchmark-marklogic-1201-1)
+    - [Key findings](#key-findings-1)
+  - [Optimization 19: DataType-split estimate for non-CTS-foldable searches](#optimization-19-datatype-split-estimate-for-non-cts-foldable-searches)
+    - [Problem](#problem-1)
+    - [Observation](#observation)
+    - [Design sketch](#design-sketch)
+    - [Scope leakage](#scope-leakage)
+    - [Constraints](#constraints)
 
 # Introduction
 
@@ -431,15 +443,15 @@ Terms composed entirely of stop words (e.g., "a the and") or punctuation-only ch
 |---|---|---|---|
 | `indexedValue` | `constraints[]` + lexicon (`op.eq`) | `ctsConstraints[]` (`cts.fieldValueQuery`) | Exact-match on `indexReferences[0]`. |
 | `indexedWord` + `_complete` | `constraints[]` + lexicon (`op.eq`) | `ctsConstraints[]` (`cts.fieldValueQuery`) | Requires range index. |
-| `indexedWord` (no `_complete`) | `ctsConstraints[]` | `ctsConstraints[]` | Word queries always use CTS — no Optic-native stemming/wildcards. |
-| `indexedRange` | `constraints[]` + lexicon (comparator) | `ctsConstraints[]` (`cts.fieldRangeQuery`) | Comparator map: `">="` → `op.ge`, `"<"` → `op.lt`, etc. |
-| `dateRange` | `constraints[]` + lexicon | `ctsConstraints[]` (`cts.fieldRangeQuery`) | Start/end date pair with comparators. |
-| `documentId` / `iri` | `constraints[]` (`op.eq(uriCol, v)`) | `ctsConstraints[]` (`cts.documentQuery`) | Treated identically. |
-| `keyword` | `ctsConstraints[]` | `ctsConstraints[]` | Always CTS — combines non-semantic field query OR semantic triple-range query. |
-| `geospatial` | `ctsConstraints[]` | `ctsConstraints[]` | CTS geospatial queries. |
-| `hopWithField` | `patternJoins[]` | `patternJoins[]` | Always joins — triples require own row source. |
-| `hopInverse` | `patternJoins[]` | `patternJoins[]` | Always joins. Has valuesOnly optimization for related lists. |
-| `annTopK` | `patternJoins[]` | `patternJoins[]` | Always joins — vector index requires own row source. |
+| `indexedWord` (no `_complete`) | `ctsConstraints[]` | Same as AND | Word queries always use CTS — no Optic-native stemming/wildcards. |
+| `indexedRange` | `ctsConstraints[]` (`cts.fieldRangeQuery`) | Same as AND | Converted from Optic comparators to CTS for CTS Fold ([Opt 18](#optimization-18-cts-estimate)) and CTS Estimate ([Opt 18](#optimization-18-cts-estimate)) eligibility. |
+| `dateRange` | `ctsConstraints[]` (`cts.fieldRangeQuery`) | Same as AND | Converted from Optic column comparisons to CTS for CTS Fold ([Opt 18](#optimization-18-cts-estimate)) and CTS Estimate ([Opt 18](#optimization-18-cts-estimate)) eligibility. |
+| `documentId` / `iri` | `ctsConstraints[]` (`cts.documentQuery`) | Same as AND | Converted from `op.eq(uriCol, v)` to CTS for CTS Fold ([Opt 18](#optimization-18-cts-estimate)) and CTS Estimate ([Opt 18](#optimization-18-cts-estimate)) eligibility. |
+| `keyword` | `ctsConstraints[]` | Same as AND | Always CTS — combines non-semantic field query OR semantic triple-range query. |
+| `geospatial` | `ctsConstraints[]` | Same as AND | CTS geospatial queries. |
+| `hopWithField` | `patternJoins[]` or `ctsConstraints[]` | Same as AND | Emits `cts.tripleRangeQuery` when inner criteria is pure CTS ([Opt 16](#optimization-16-hopwithfield-cts)); otherwise joins. |
+| `hopInverse` | `patternJoins[]` | Same as AND | Always joins. Has valuesOnly optimization for related lists. |
+| `annTopK` | `patternJoins[]` | Same as AND | Always joins — vector index requires own row source. |
 
 ## `keyword` Details
 
@@ -888,6 +900,7 @@ Performance opportunities that could be implemented above the backend (mostly).
 | 5 | [Opt 16](#optimization-16-hopwithfield-cts) | HopWithField CTS: emit `cts.tripleRangeQuery` instead of Optic `fromTriples` join when inner criteria is pure CTS | 2026-06-04 |
 | 6 | [Opt 1](#optimization-1-planwhere-when-scores-are-not-needed) | Score gate: use `plan.where()` instead of `op.fromSearch` when scores are not needed (3-condition gate) | 2026-06-24 |
 | 7 | [Opt 17](#optimization-17-select-barrier-on-nested-sub-plans) | Select barrier: `.select([iriCol, fragCol])` on nested sub-plans prevents optimizer from fusing join trees across nesting levels (764× warm improvement on 3-level hops) | 2026-06-24 |
+| 8 | [Opt 18](#optimization-18-cts-estimate) | CTS Estimate: when CTS Fold ([Opt 15](#optimization-15-cts-fold)) is applicable, use `cts.estimate` for total count and `.offset().limit()` for the requested page's results. Avoids materializing all rows. | 2026-06-26 |
 
 ## Data Type Constraint Optimizations
 
@@ -1337,3 +1350,128 @@ All variants use the discovery query above. Each execution returned 11 results (
 - **A (minimal lexicons):** 16× cold improvement over baseline (8,594ms → 533ms). Reducing the column count shrinks the optimization scope enough to avoid the worst cross-product strategies, but without a hard projection barrier the optimizer can still see more columns than necessary. Warm runs (292ms) remain ~26× slower than the barrier approach.
 - **B (inside-out assembly):** No improvement. Confirms the problem is optimizer join fusion, not plan construction order. The optimizer freely reorders joins regardless of how the application builds them.
 - **Why the barrier dominates:** Variant A improves cold starts by reducing column count, but the optimizer can still reason across the join boundary. The select barrier (variant C) creates an opaque wall — the optimizer treats each sub-plan as a black box returning exactly two columns. This prevents cross-level fusion entirely, which explains the additional 2× cold improvement and 26× warm improvement over variant A.
+
+## Optimization 18: CTS Estimate
+
+**Status:** Implemented.
+
+This is an extension of the CTS Fold [(Opt 15)](#optimization-15-cts-fold) optimization.  When that optimization is applicable to a search request, this one can be as well.
+
+### Problem
+
+`performSearch` in `engine.mjs` materializes **all** matching rows into a JavaScript array to compute `total`:
+
+```javascript
+const rows = useThisPlan.result().toArray();
+total = rows.length;
+const page = rows.slice(offset, offset + pageLength);
+```
+
+For queries with large result sets (e.g., `item.memberOf` returning 2.5M rows), this costs 15 seconds — regardless of requested page size. The Optic plan itself (with `.offset().limit()`) takes only 3–4 seconds for the same query. The more results a search matches, the more this optimization pays off — materialization cost scales linearly with row count while `cts.estimate` is O(1).
+
+Original search that got us looking at this:
+
+```json
+{
+  "_scope": "item",
+  "memberOf": {
+    "id": "https://lux.collections.yale.edu/data/set/d1b8a867-8be7-4325-ad78-1f3abda76056"
+  }
+}
+```
+
+The above ID resolved to "Sterling Memorial Library, Yale University Library" at the time.
+
+### When CTS Estimate applies
+
+The logic of when CTS Estimate applies is defined in [engine.mjs](/src/main/ml-modules/root/lib/search/engine.mjs)'s `canUseEstimate`.  All of the following must be true:
+
+1. **The top-level accumulator is join-free** (`isAccumulatorJoinFree`): no `patternJoins`, no `andOrSubPlans`, no `conjunctionJoins`, at least one `ctsConstraint`, and no pattern-added Optic `constraints` beyond the initial dataType constraint.
+2. **The request includes search results** (`includeSearchResults` is true). Facet-only requests take a different path.
+3. **No `pageWith`** is requested. `pageWith` requires locating a specific document's position in the full result set.
+4. **No facet requests.** Facets require aggregation over the full result set.
+5. **`buildEstimateQuery` returns non-null.** This composes the CTS query with a scope dataType filter (`cts.fieldValueQuery('anyDataTypeName', scopeTypes)`) so cross-scope fields like `anyAnyText` don't overcount.
+
+### Pattern CTS Conversions
+
+While implementing this optimization, patterns were reviewed to see if they could enable the CTS Fold [(Opt 15)](#optimization-15-cts-fold) and CTS Estimate [(Opt 18)](#optimization-18-cts-estimate) optimizations to apply to more searches.
+
+We were able to do so to three patterns: `DateRange`, `DocumentIdOrIri`, and `IndexedRange`.
+
+The only patterns that still produce non-CTS contributions are `hopWithField` (when inner criteria requires Optic joins or when transitive), `hopInverse`, and `annTopK` — all of which inherently require Optic joins for triple navigation or vector search.
+
+### Benchmark (MarkLogic 12.0.1)
+
+Multiple ways to get the estimate were benchmarked using the `item.memberOf` query — 2,553,512 matching rows.
+
+| # | Approach | Estimate | Cold (ms) | Warm avg (ms) | Notes |
+|---|---|---|---|---|---|
+| 1 | `.result().toArray().length` (baseline) | 2,553,512 | 15,158 | 15,049 | Full materialization |
+| 2 | `fn.count(plan.result())` | 2,553,512 | 4,376 | 4,420 | No array allocation; iterates lazily |
+| 3 | `plan.groupBy(null, op.count('total'))` | 2,553,512 | 35,744 | 35,436 | Optimizer picks catastrophic aggregation plan |
+| 4 | `plan.explain()` → `estimated-count` | 218,955 | 402 | 379 | Off by 11.6× — unusable |
+| 5 | `cts.estimate(ctsQuery)` | 2,553,512 | <1 | ~0 | **Exact match**, O(1) from indexes |
+| 6 | Two-pass: `cts.estimate` + `.offset().limit()` | 2,553,512 | 3,863 | 3,594 | **4.2× faster than baseline** |
+
+### Key findings
+
+1. **`cts.estimate` is exact for this query shape.** The 2,553,512 count matches full materialization. No dedup gap because `groupBy(['uri'])` deduplicated nothing — each matching URI appears once per field value match.
+2. **`cts.estimate` is free.** Sub-millisecond cold, effectively zero warm.
+3. **The two-pass approach is the clear winner.** `cts.estimate` for total + `.offset(n).limit(m).result()` for the page: 3.6s vs 15s.
+4. **V8 array allocation is the dominant cost.** `fn.count` (lazy iteration) is 3.4× faster than `.toArray().length` — the 2.5M-object heap allocation costs ~10s alone.
+5. **`groupBy(null, count)` is catastrophically slow.** The optimizer chooses a worse plan for the count-only aggregation than for full row retrieval.
+6. **`plan.explain()` estimates are wildly inaccurate** — 8.6% of true count for this query. Not usable.
+
+## Optimization 19: DataType-split estimate for non-CTS-foldable searches
+
+**Status:** Idea — needs investigation and benchmarking.
+
+### Problem
+
+CTS Estimate (Opt 18) only fires when the top-level accumulator is join-free — i.e., every pattern contribution is pure CTS. Searches involving `hopWithField` (when inner criteria requires Optic joins), `hopInverse`, or `annTopK` produce `patternJoins` that make the accumulator non-join-free. These searches still materialize all rows to compute `total`, which is the dominant cost for large result sets.
+
+### Observation
+
+The `dataType` column serves two purposes in the current pipeline:
+
+1. **Filtering** — `op.in(op.col('dataType'), scopeTypes)` constrains `fromLexicons` to the correct scope.
+2. **Output projection** — `collapseToResultRows` renames `dataType` → `type` in the final `select()` so the caller knows each result's record type.
+
+For the *count*, only filtering matters — we need to know *how many* URIs match, not *what type* they are. For the *page*, both matter — each result row includes `{ id, type }`.
+
+### Design sketch
+
+Split `performSearch`'s else-branch into two executions when CTS Estimate is ineligible:
+
+1. **Page results (with dataType):** Execute the full plan with `.offset().limit()` to get the requested page. This includes the `dataType` lexicon, constraint, and `groupBy` aggregation — producing `{ id, type }` rows. Cost: proportional to page size (e.g., 20 rows), not total result count.
+
+2. **Estimate (without dataType):** Build a parallel "count plan" that omits the `dataType` lexicon and `op.in` constraint entirely. Execute it with `fn.count(plan.result())` (lazy iteration, no array allocation) or `.groupBy(null, op.count('total'))`. Cost: avoids the `anyDataTypeName` lexicon scan (44M entries) and the early-join filter, at the expense of cross-scope false positives.
+
+```javascript
+// Conceptual — not production-ready
+if (canEstimate) {
+  // ... existing Opt 18 path ...
+} else if (includeSearchResults && !pageWith && !facetRequests?.length) {
+  // Page results with dataType
+  searchResults = useThisPlan.offset(offset).limit(pageLength).result().toArray();
+  // Estimate without dataType (may overcount by including other scopes' documents)
+  total = fn.count(countOnlyPlan.result());
+} else {
+  // Full materialization (facets, pageWith, etc.)
+  const rows = useThisPlan.result().toArray();
+  // ...
+}
+```
+
+### Scope leakage
+
+Omitting the `dataType` constraint from the count plan means results from other search scopes could be included in the rows being counted for the "estimate".  This could only happen when there are no scope-specific constraints (e.g., scope-specific fields and predicates).  Optimization ideas [Opt 12 (scope-specific predicates)](#optimization-12-scope-specific-predicates-to-eliminate-datatype-constraints) could reduce or eliminate the leakage. 
+
+Scope leakage may be acceptable for estimates, especially if for a minority subset of searches.
+
+### Constraints
+
+- **Not for facets.** Facet computation requires the full row set with correct scope filtering — an overcounting estimate would silently corrupt facet totals.
+- **Not for `pageWith`.** The `pageWith` path needs to locate a specific document's position in the full result set.
+- **Plan construction cost.** Building a second plan (without dataType) doubles the `buildPlans` work. This may be mitigable by sharing the analysis pass and only diverging at `createPlanAccumulator`.
+- **Memory safety.** The Opt 3 investigation showed that removing the dataType constraint from hop sub-plans caused SVC-MEMCANCELED. The count plan would remove it only from the *top-level* accumulator — hop sub-plans would retain their constraints. This distinction needs validation.

--- a/src/main/ml-modules/root/lib/search/engine.mjs
+++ b/src/main/ml-modules/root/lib/search/engine.mjs
@@ -106,13 +106,14 @@ function performSearch(scp) {
         });
       }
 
-      const { sortedResultsPlan, unsortedResultsPlan } = buildPlans({
-        scp,
-        analysis,
-        groups: getResultRowGrouping(),
-        sortCriteria: scp.getSortCriteria(),
-        patternOptions,
-      });
+      const { sortedResultsPlan, unsortedResultsPlan, estimateQuery } =
+        buildPlans({
+          scp,
+          analysis,
+          groups: getResultRowGrouping(),
+          sortCriteria: scp.getSortCriteria(),
+          patternOptions,
+        });
 
       let useThisPlan = includeSearchResults
         ? sortedResultsPlan
@@ -128,22 +129,41 @@ function performSearch(scp) {
       planAsJson = useThisPlan.export();
       planAsSource = getPlanSource(planAsJson);
 
-      const rows = useThisPlan.result().toArray();
+      // Opt 18: use cts.estimate + offset/limit when eligible.
+      const canEstimate =
+        includeSearchResults &&
+        !pageWith &&
+        !facetRequests?.length &&
+        estimateQuery != null;
 
-      if (includeSearchResults) {
-        total = rows.length;
-        const paginationResult = paginateResults({
-          rows,
-          pageWith,
-          page,
-          pageLength: pageLength ?? 20,
-        });
-        resultPage = paginationResult.resultPage;
-        searchResults = paginationResult.searchResults;
+      if (canEstimate) {
+        const effectivePageLength = pageLength ?? 20;
+        total = cts.estimate(estimateQuery);
+        resultPage = Math.max(page, 1);
+        const offset = (resultPage - 1) * effectivePageLength;
+        searchResults = useThisPlan
+          .offset(offset)
+          .limit(effectivePageLength)
+          .result()
+          .toArray();
+      } else {
+        const rows = useThisPlan.result().toArray();
+
+        if (includeSearchResults) {
+          total = rows.length;
+          const paginationResult = paginateResults({
+            rows,
+            pageWith,
+            page,
+            pageLength: pageLength ?? 20,
+          });
+          resultPage = paginationResult.resultPage;
+          searchResults = paginationResult.searchResults;
+        }
+
+        // calculateFacets returns null when facets are not requested.
+        facetResponses = calculateFacets(rows, facetRequests);
       }
-
-      // calculateFacets returns null when facets are not requested.
-      facetResponses = calculateFacets(rows, facetRequests);
     }
 
     return new SearchExecutionResult({
@@ -307,7 +327,16 @@ function buildPlans({
     groups,
   });
 
-  return { sortedResultsPlan, unsortedResultsPlan };
+  // Opt 18: compute a CTS query for cts.estimate when the top-level
+  // accumulator is join-free (only base constraints + CTS queries).
+  // Returns null when the plan requires full materialization.
+  const estimateQuery = buildEstimateQuery(
+    acc,
+    assemblyContext,
+    analysis.scope,
+  );
+
+  return { sortedResultsPlan, unsortedResultsPlan, estimateQuery };
 }
 //#endregion
 
@@ -430,16 +459,18 @@ function createPlanAccumulator({
   dataTypeCol,
   isMultiScope,
 }) {
+  const constraints =
+    isMultiScope || scopeAlreadyConstrained
+      ? []
+      : [op.in(op.col(dataTypeCol), getSearchScopeTypes(scope, false))];
   return {
     lexicons: {
       [uriCol]: cts.uriReference(),
       [iriCol]: cts.iriReference(),
       [dataTypeCol]: cts.fieldReference('anyDataTypeName'),
     },
-    constraints:
-      isMultiScope || scopeAlreadyConstrained
-        ? []
-        : [op.in(op.col(dataTypeCol), getSearchScopeTypes(scope, false))],
+    constraints,
+    _initialConstraintCount: constraints.length,
     ctsConstraints: [],
     conjunctionJoins: [],
     andOrSubPlans: [],
@@ -1191,6 +1222,38 @@ function accContainsOnly(acc, bucketName) {
   return ACC_CONTENT_BUCKETS.every(
     (b) => b === bucketName || acc[b].length === 0,
   );
+}
+
+// True when the accumulator has no Optic joins and no pattern-contributed
+// Optic constraints — only the initial dataType constraint and CTS queries.
+// Patterns like DateRange and IndexedRange add op.ge/op.le to constraints;
+// cts.estimate can't evaluate those, so the fast path must not fire.
+function accIsJoinFree(acc) {
+  return (
+    acc.conjunctionJoins.length === 0 &&
+    acc.andOrSubPlans.length === 0 &&
+    acc.patternJoins.length === 0 &&
+    acc.ctsConstraints.length > 0 &&
+    acc.constraints.length === acc._initialConstraintCount
+  );
+}
+
+// Opt 18: Returns a composed CTS query suitable for cts.estimate when the
+// accumulator is join-free, or null when full materialization is required.
+// Includes the scope's dataType filter so fields spanning scopes (e.g.
+// anyAnyText) don't overcount.
+function buildEstimateQuery(acc, assemblyContext, scope) {
+  if (!accIsJoinFree(acc)) return null;
+  const composedCts = wrapCtsByLogicType(
+    assemblyContext.logicType,
+    acc.ctsConstraints,
+  );
+  const scopeTypes = getSearchScopeTypes(scope, false);
+  if (scopeTypes.length === 0) return composedCts;
+  return cts.andQuery([
+    composedCts,
+    cts.fieldValueQuery('anyDataTypeName', scopeTypes),
+  ]);
 }
 //#endregion
 

--- a/src/main/ml-modules/root/lib/search/engine.mjs
+++ b/src/main/ml-modules/root/lib/search/engine.mjs
@@ -130,11 +130,12 @@ function performSearch(scp) {
       planAsSource = getPlanSource(planAsJson);
 
       // Opt 18: use cts.estimate + offset/limit when eligible.
-      const canEstimate =
-        includeSearchResults &&
-        !pageWith &&
-        !facetRequests?.length &&
-        estimateQuery != null;
+      const canEstimate = canUseEstimate({
+        includeSearchResults,
+        pageWith,
+        facetRequests,
+        estimateQuery,
+      });
 
       if (canEstimate) {
         const effectivePageLength = pageLength ?? 20;
@@ -860,6 +861,54 @@ function collapseToResultRows(
 
   return plan;
 }
+
+// True when the accumulator has no Optic joins and no pattern-contributed
+// Optic constraints — only the initial dataType constraint and CTS queries.
+// Patterns like DateRange and IndexedRange add op.ge/op.le to constraints;
+// cts.estimate can't evaluate those, so the fast path must not fire.
+function isAccumulatorJoinFree(acc) {
+  return (
+    acc.conjunctionJoins.length === 0 &&
+    acc.andOrSubPlans.length === 0 &&
+    acc.patternJoins.length === 0 &&
+    acc.ctsConstraints.length > 0 &&
+    acc.constraints.length === acc._initialConstraintCount
+  );
+}
+
+// Opt 18: Returns a composed CTS query suitable for cts.estimate when the
+// accumulator is join-free, or null when full materialization is required.
+// Includes the scope's dataType filter so fields spanning scopes (e.g.
+// anyAnyText) don't overcount.
+function buildEstimateQuery(acc, assemblyContext, scope) {
+  if (!isAccumulatorJoinFree(acc)) return null;
+  const composedCts = wrapCtsByLogicType(
+    assemblyContext.logicType,
+    acc.ctsConstraints,
+  );
+  const scopeTypes = getSearchScopeTypes(scope, false);
+  if (scopeTypes.length === 0) return composedCts;
+  return cts.andQuery([
+    composedCts,
+    cts.fieldValueQuery('anyDataTypeName', scopeTypes),
+  ]);
+}
+
+// Opt 18: returns true when the request shape and plan structure allow
+// cts.estimate to replace full materialization for counting.
+function canUseEstimate({
+  includeSearchResults,
+  pageWith,
+  facetRequests,
+  estimateQuery,
+}) {
+  return (
+    includeSearchResults &&
+    !pageWith &&
+    !facetRequests?.length &&
+    estimateQuery != null
+  );
+}
 //#endregion
 
 //#region Facets
@@ -1223,38 +1272,6 @@ function accContainsOnly(acc, bucketName) {
     (b) => b === bucketName || acc[b].length === 0,
   );
 }
-
-// True when the accumulator has no Optic joins and no pattern-contributed
-// Optic constraints — only the initial dataType constraint and CTS queries.
-// Patterns like DateRange and IndexedRange add op.ge/op.le to constraints;
-// cts.estimate can't evaluate those, so the fast path must not fire.
-function accIsJoinFree(acc) {
-  return (
-    acc.conjunctionJoins.length === 0 &&
-    acc.andOrSubPlans.length === 0 &&
-    acc.patternJoins.length === 0 &&
-    acc.ctsConstraints.length > 0 &&
-    acc.constraints.length === acc._initialConstraintCount
-  );
-}
-
-// Opt 18: Returns a composed CTS query suitable for cts.estimate when the
-// accumulator is join-free, or null when full materialization is required.
-// Includes the scope's dataType filter so fields spanning scopes (e.g.
-// anyAnyText) don't overcount.
-function buildEstimateQuery(acc, assemblyContext, scope) {
-  if (!accIsJoinFree(acc)) return null;
-  const composedCts = wrapCtsByLogicType(
-    assemblyContext.logicType,
-    acc.ctsConstraints,
-  );
-  const scopeTypes = getSearchScopeTypes(scope, false);
-  if (scopeTypes.length === 0) return composedCts;
-  return cts.andQuery([
-    composedCts,
-    cts.fieldValueQuery('anyDataTypeName', scopeTypes),
-  ]);
-}
 //#endregion
 
 export {
@@ -1262,6 +1279,7 @@ export {
   analyzeLeafCriteria,
   buildPlans,
   buildSortedResultsPlan,
+  canUseEstimate,
   getResultRowGrouping,
   paginateResults,
   performSearch,

--- a/src/main/ml-modules/root/lib/search/engine.mjs
+++ b/src/main/ml-modules/root/lib/search/engine.mjs
@@ -1277,10 +1277,12 @@ function accContainsOnly(acc, bucketName) {
 export {
   MAXIMUM_PAGE_WITH_LENGTH,
   analyzeLeafCriteria,
+  buildEstimateQuery,
   buildPlans,
   buildSortedResultsPlan,
   canUseEstimate,
   getResultRowGrouping,
+  isAccumulatorJoinFree,
   paginateResults,
   performSearch,
   processNestedCriteria,

--- a/src/main/ml-modules/root/lib/search/patterns/DateRange.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/DateRange.mjs
@@ -1,16 +1,13 @@
-import op from '/MarkLogic/optic.mjs';
 import { isArray } from '../../../utils/utils.mjs';
 import { convertPartialDateTimeToSeconds } from '../../../utils/dateUtils.mjs';
 import {
   InternalServerError,
   InvalidSearchRequestError,
 } from '../../errorClasses.mjs';
-import { COMPARATORS } from '../../SearchCriteriaProcessor.mjs';
 import { SearchPatternBase, CHILD_TYPE_ATOMIC } from './SearchPatternBase.mjs';
 
 class DateRange extends SearchPatternBase {
   apply(scp, searchTerm, logicType, patternOptions) {
-    const id = searchTerm.getId();
     const name = searchTerm.getName();
     const termValue = searchTerm.getValue();
     const termConfig = searchTerm.getSearchTermConfig();
@@ -27,17 +24,13 @@ class DateRange extends SearchPatternBase {
     // Determine which indexes to use based on timespanMode
     let startIndexName;
     let endIndexName;
-    let startColName = id + '_start';
-    let endColName = id + '_end';
     const timespanMode = searchTerm.getTimespanMode();
     if (timespanMode === 'begin') {
       startIndexName = termConfig.getIndexReferences()[0];
       endIndexName = termConfig.getIndexReferences()[0];
-      endColName = startColName;
     } else if (timespanMode === 'end') {
       startIndexName = termConfig.getIndexReferences()[1];
       endIndexName = termConfig.getIndexReferences()[1];
-      startColName = endColName;
     } else {
       // 'full' or default
       startIndexName = termConfig.getIndexReferences()[0];
@@ -76,41 +69,33 @@ class DateRange extends SearchPatternBase {
     const startDateLong = convertPartialDateTimeToSeconds(startDateStr, true);
     const endDateLong = convertPartialDateTimeToSeconds(endDateStr, false);
 
-    // Set up the Optic query's constraints and lexicons.
+    // All operators use cts.fieldRangeQuery for Opt 18 compatibility.
     // Operators > and >= test the document's start date (qS).
-    // Operators < and <= test the document's end date (qE).
-    // Operator = tests both (overlap). Operator != uses CTS.
-    const constraints = [];
+    // Operators < and <= test the document's start date (qS).
+    // Operator = tests both (overlap). Operator != uses OR of two ranges.
     const ctsConstraints = [];
-    const needStartCol = ['>', '>=', '<', '<=', '=', '!='].includes(operator);
-    const needEndCol = ['='].includes(operator);
-    const lexicons = {};
-    if (needStartCol) {
-      lexicons[startColName] = cts.fieldReference(startIndexName);
-    }
-    if (needEndCol) {
-      lexicons[endColName] = cts.fieldReference(endIndexName);
-    }
 
     if (['>', '>=', '<', '<='].includes(operator)) {
       // All single-sided operators test the document's start date (qS).
       // Use the start of the search date for >= and <; the end of the search date for > and <=.
-      // Example: ">= 1800" requires qS >= 1800-01-01T00:00:00.
-      // Example: "< 1800" requires qS < 1800-01-01T00:00:00.
-      const colName = startColName;
       const dateLong = ['>=', '<'].includes(operator)
         ? startDateLong
         : endDateLong;
-      constraints.push(COMPARATORS[operator](op.col(colName), dateLong));
+      ctsConstraints.push(
+        cts.fieldRangeQuery(startIndexName, operator, dateLong),
+      );
     } else if (operator === '=') {
       // Overlap: a document qualifies if its timespan [qS, qE] overlaps the search range [aS, aE].
       // Condition: qS <= aE AND qE >= aS
-      constraints.push(op.le(op.col(startColName), endDateLong));
-      constraints.push(op.ge(op.col(endColName), startDateLong));
+      ctsConstraints.push(
+        cts.fieldRangeQuery(startIndexName, '<=', endDateLong),
+      );
+      ctsConstraints.push(
+        cts.fieldRangeQuery(endIndexName, '>=', startDateLong),
+      );
     } else if (operator === '!=') {
       // Complement of overlap: a document qualifies if its timespan does NOT overlap [aS, aE].
       // Condition: qS > aE OR qE < aS
-      // Note: startIndexName and endIndexName are already adjusted by timespanMode above.
       ctsConstraints.push(
         cts.orQuery([
           cts.fieldRangeQuery(startIndexName, '>', endDateLong),
@@ -123,11 +108,7 @@ class DateRange extends SearchPatternBase {
       );
     }
 
-    return {
-      constraints,
-      ctsConstraints,
-      lexicons,
-    };
+    return { ctsConstraints };
   }
 
   mayTokenizeValue() {

--- a/src/main/ml-modules/root/lib/search/patterns/DocumentIdOrIri.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/DocumentIdOrIri.mjs
@@ -1,20 +1,9 @@
-import op from '/MarkLogic/optic.mjs';
 import { CHILD_TYPE_ATOMIC, SearchPatternBase } from './SearchPatternBase.mjs';
 
 class DocumentIdOrIri extends SearchPatternBase {
   apply(scp, searchTerm, logicType, patternOptions) {
     const termValue = searchTerm.getValue();
-    const uriCol = searchTerm.getParentUriColumn();
-
-    return logicType === 'and'
-      ? {
-          constraints: [op.eq(op.col(uriCol), termValue)],
-        }
-      : {
-          // ctsConstraints proven to be required for OR, at least given engine's
-          // implementation at the time.
-          ctsConstraints: [cts.documentQuery(termValue)],
-        };
+    return { ctsConstraints: [cts.documentQuery(termValue)] };
   }
 
   mayTokenizeValue() {

--- a/src/main/ml-modules/root/lib/search/patterns/IndexedRange.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/IndexedRange.mjs
@@ -1,28 +1,10 @@
-import op from '/MarkLogic/optic.mjs';
-import { COMPARATORS } from '../../SearchCriteriaProcessor.mjs';
 import { CHILD_TYPE_ATOMIC, SearchPatternBase } from './SearchPatternBase.mjs';
 
 class IndexedRange extends SearchPatternBase {
   apply(scp, searchTerm, logicType, patternOptions) {
-    const id = searchTerm.getId();
     const termValue = searchTerm.getValue();
     const termConfig = searchTerm.getSearchTermConfig();
 
-    // NOTE: If we switch to fromView, we can restrict criteria to a single object's values versus
-    // including the values of all objects in the array.
-    if (logicType === 'and') {
-      const fieldCol = id + '_field';
-      const constraint = COMPARATORS[searchTerm.getComparisonOperator()];
-      // This requires that each term config only has one index reference. This is true today, but is it guaranteed?
-      return {
-        lexicons: {
-          [fieldCol]: cts.fieldReference(termConfig.getIndexReferences()[0]),
-        },
-        constraints: [constraint(op.col(fieldCol), termValue)],
-      };
-    }
-
-    // OR and NOT
     return {
       ctsConstraints: [
         cts.fieldRangeQuery(

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0407 buildPlans-hopWithFieldCtsOptimization.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0407 buildPlans-hopWithFieldCtsOptimization.mjs
@@ -83,19 +83,39 @@ const scenarios = [
     },
   },
 
-  // --- Optimization does NOT fire ---
-  // Note: HopWithField rejects atomic values (getAllowedChildren excludes
-  // CHILD_TYPE_ATOMIC), so there is no atomic-value fallback to test.
   {
-    name: 'Inner criteria with non-CTS contributions falls back to Optic join',
+    name: 'Nested AND with id and name folds to CTS (DocumentIdOrIri is pure CTS)',
     input: {
       scopeName: 'work',
       searchCriteria: {
         _scope: 'work',
-        // DocumentIdOrIri returns Optic constraints (not ctsConstraints) for
-        // AND logic, so the inner accumulator is not pure CTS and
-        // processNestedCriteriaAsCts returns null → Optic fallback fires.
+        // After CTS conversion, DocumentIdOrIri returns ctsConstraints for all
+        // logicTypes. Combined with name (indexedWord → ctsConstraints), the
+        // inner accumulator is pure CTS and processNestedCriteriaAsCts succeeds.
         classification: { AND: [{ id: MOCK_IRI }, { name: 'painting' }] },
+      },
+    },
+    expected: {
+      error: false,
+      planContains: ['cts.tripleRangeQuery', 'workClassifiedAs'],
+      planExcludes: ['op.fromTriples'],
+    },
+  },
+
+  // --- Optimization does NOT fire ---
+  // Note: HopWithField rejects atomic values (getAllowedChildren excludes
+  // CHILD_TYPE_ATOMIC), so there is no atomic-value fallback to test.
+  {
+    name: 'Inner criteria with HopInverse term falls back to Optic join',
+    input: {
+      scopeName: 'work',
+      searchCriteria: {
+        _scope: 'work',
+        // narrower is a HopInverse pattern in concept scope (inverse of
+        // broader). HopInverse always returns patternJoins, so the inner
+        // accumulator is not pure CTS → processNestedCriteriaAsCts returns
+        // null → Optic fallback fires.
+        classification: { narrower: { name: 'painting' } },
       },
     },
     expected: {

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0600 getEstimate.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0600 getEstimate.mjs
@@ -833,6 +833,110 @@ const scenarios = [
       stackToInclude: 'Unsupported geospatial operator',
     },
   },
+  // IndexedRange operator coverage (CTS conversion validation).
+  // All operators previously used COMPARATORS[op] in the AND path; now use cts.fieldRangeQuery.
+  {
+    name: 'item depth > 100 (IndexedRange > in AND)',
+    input: {
+      searchCriteria: {
+        _scope: 'item',
+        depth: '100',
+        _comp: '>',
+      },
+    },
+    expected: {
+      error: false,
+      value: 1,
+    },
+  },
+  {
+    name: 'item width < 100 (IndexedRange < in AND)',
+    input: {
+      searchCriteria: {
+        _scope: 'item',
+        width: '100',
+        _comp: '<',
+      },
+    },
+    expected: {
+      error: false,
+      value: 785,
+    },
+  },
+  {
+    name: 'item height <= 100 (IndexedRange <= in AND)',
+    input: {
+      searchCriteria: {
+        _scope: 'item',
+        height: '100',
+        _comp: '<=',
+      },
+    },
+    expected: {
+      error: false,
+      value: 853,
+    },
+  },
+  {
+    name: 'item depth >= 100 standalone (IndexedRange >= in AND)',
+    input: {
+      searchCriteria: {
+        _scope: 'item',
+        depth: '100',
+        _comp: '>=',
+      },
+    },
+    expected: {
+      error: false,
+      value: 1,
+    },
+  },
+  {
+    name: 'item NOT depth >= 100 (IndexedRange in NOT)',
+    input: {
+      searchCriteria: {
+        _scope: 'item',
+        NOT: [{ depth: '100', _comp: '>=' }],
+      },
+    },
+    expected: {
+      error: false,
+      value: 2742,
+    },
+  },
+  {
+    name: 'item AND with IndexedRange > and < (two operators)',
+    input: {
+      searchCriteria: {
+        _scope: 'item',
+        AND: [
+          { depth: '50', _comp: '>' },
+          { depth: '200', _comp: '<' },
+        ],
+      },
+    },
+    expected: {
+      error: false,
+      value: 18,
+    },
+  },
+  {
+    name: 'agent NOT by ID (DocumentIdOrIri in NOT)',
+    input: {
+      searchCriteria: {
+        _scope: 'agent',
+        NOT: [
+          {
+            id: 'https://lux.collections.yale.edu/data/group/f49ccc7b-5d4e-4121-8210-b57bc89aad5a',
+          },
+        ],
+      },
+    },
+    expected: {
+      error: false,
+      value: 6240,
+    },
+  },
 ];
 
 // Test getEstimate scenarios

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0601 canUseEstimate.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0601 canUseEstimate.mjs
@@ -1,0 +1,135 @@
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { canUseEstimate } from '/lib/search/engine.mjs';
+
+const LIB = '0601 canUseEstimate.mjs';
+console.log(`${LIB}: starting.`);
+
+const MOCK_ESTIMATE_QUERY = cts.andQuery([cts.trueQuery()]);
+
+const scenarios = [
+  // --- All conditions met → true ---
+  {
+    name: 'all conditions met',
+    input: {
+      includeSearchResults: true,
+      pageWith: null,
+      facetRequests: null,
+      estimateQuery: MOCK_ESTIMATE_QUERY,
+    },
+    expected: true,
+  },
+  {
+    name: 'facetRequests is empty array',
+    input: {
+      includeSearchResults: true,
+      pageWith: null,
+      facetRequests: [],
+      estimateQuery: MOCK_ESTIMATE_QUERY,
+    },
+    expected: true,
+  },
+  {
+    name: 'facetRequests is undefined',
+    input: {
+      includeSearchResults: true,
+      pageWith: null,
+      facetRequests: undefined,
+      estimateQuery: MOCK_ESTIMATE_QUERY,
+    },
+    expected: true,
+  },
+
+  // --- Each condition individually false → false ---
+  {
+    name: 'includeSearchResults is false',
+    input: {
+      includeSearchResults: false,
+      pageWith: null,
+      facetRequests: null,
+      estimateQuery: MOCK_ESTIMATE_QUERY,
+    },
+    expected: false,
+  },
+  {
+    name: 'pageWith is set',
+    input: {
+      includeSearchResults: true,
+      pageWith: 'https://example.com/doc/1',
+      facetRequests: null,
+      estimateQuery: MOCK_ESTIMATE_QUERY,
+    },
+    expected: false,
+  },
+  {
+    name: 'facetRequests has entries',
+    input: {
+      includeSearchResults: true,
+      pageWith: null,
+      facetRequests: [{ name: 'responsibleUnits' }],
+      estimateQuery: MOCK_ESTIMATE_QUERY,
+    },
+    expected: false,
+  },
+  {
+    name: 'estimateQuery is null (plan requires full materialization)',
+    input: {
+      includeSearchResults: true,
+      pageWith: null,
+      facetRequests: null,
+      estimateQuery: null,
+    },
+    expected: false,
+  },
+
+  // --- Multiple conditions false simultaneously ---
+  {
+    name: 'pageWith set and estimateQuery null',
+    input: {
+      includeSearchResults: true,
+      pageWith: 'https://example.com/doc/1',
+      facetRequests: null,
+      estimateQuery: null,
+    },
+    expected: false,
+  },
+  {
+    name: 'no search results and facets requested',
+    input: {
+      includeSearchResults: false,
+      pageWith: null,
+      facetRequests: [{ name: 'responsibleUnits' }],
+      estimateQuery: MOCK_ESTIMATE_QUERY,
+    },
+    expected: false,
+  },
+  {
+    name: 'all conditions false',
+    input: {
+      includeSearchResults: false,
+      pageWith: 'https://example.com/doc/1',
+      facetRequests: [{ name: 'responsibleUnits' }],
+      estimateQuery: null,
+    },
+    expected: false,
+  },
+];
+
+const assertions = [];
+
+for (const scenario of scenarios) {
+  const actual = canUseEstimate(scenario.input);
+  assertions.push(
+    testHelperProxy.assertEqual(
+      scenario.expected,
+      actual,
+      `Scenario '${scenario.name}': expected ${scenario.expected}, got ${actual}`,
+    ),
+  );
+}
+
+console.log(
+  `${LIB}: completed ${assertions.length} assertions from ${scenarios.length} scenarios.`,
+);
+
+assertions;
+export default assertions;

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0602 isAccumulatorJoinFree.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0602 isAccumulatorJoinFree.mjs
@@ -1,0 +1,90 @@
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { isAccumulatorJoinFree } from '/lib/search/engine.mjs';
+
+const LIB = '0602 isAccumulatorJoinFree.mjs';
+console.log(`${LIB}: starting.`);
+
+const assertions = [];
+
+function makeAcc(overrides = {}) {
+  return {
+    constraints: [],
+    _initialConstraintCount: 0,
+    ctsConstraints: [cts.trueQuery()],
+    conjunctionJoins: [],
+    andOrSubPlans: [],
+    patternJoins: [],
+    ...overrides,
+  };
+}
+
+const scenarios = [
+  {
+    name: 'pure CTS with no joins returns true',
+    acc: makeAcc(),
+    expected: true,
+  },
+  {
+    name: 'dataType constraint only (matching initial count) returns true',
+    acc: makeAcc({
+      constraints: ['dataTypeConstraint'],
+      _initialConstraintCount: 1,
+    }),
+    expected: true,
+  },
+  {
+    name: 'conjunctionJoins present returns false',
+    acc: makeAcc({ conjunctionJoins: [{ type: 'joinInner' }] }),
+    expected: false,
+  },
+  {
+    name: 'andOrSubPlans present returns false',
+    acc: makeAcc({ andOrSubPlans: [{ plan: {} }] }),
+    expected: false,
+  },
+  {
+    name: 'patternJoins present returns false',
+    acc: makeAcc({ patternJoins: [{ right: {}, on: [] }] }),
+    expected: false,
+  },
+  {
+    name: 'no ctsConstraints returns false',
+    acc: makeAcc({ ctsConstraints: [] }),
+    expected: false,
+  },
+  {
+    name: 'pattern-added constraint beyond initial count returns false',
+    acc: makeAcc({
+      constraints: ['dataType', 'patternAdded'],
+      _initialConstraintCount: 1,
+    }),
+    expected: false,
+  },
+  {
+    name: 'multiple ctsConstraints with no joins returns true',
+    acc: makeAcc({
+      ctsConstraints: [cts.trueQuery(), cts.trueQuery()],
+      constraints: ['dataType'],
+      _initialConstraintCount: 1,
+    }),
+    expected: true,
+  },
+];
+
+for (const scenario of scenarios) {
+  const actual = isAccumulatorJoinFree(scenario.acc);
+  assertions.push(
+    testHelperProxy.assertEqual(
+      scenario.expected,
+      actual,
+      `Scenario '${scenario.name}': expected ${scenario.expected}, got ${actual}`,
+    ),
+  );
+}
+
+console.log(
+  `${LIB}: completed ${assertions.length} assertions from ${scenarios.length} scenarios.`,
+);
+
+assertions;
+export default assertions;

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0603 buildEstimateQuery.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0603 buildEstimateQuery.mjs
@@ -1,0 +1,126 @@
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { buildEstimateQuery } from '/lib/search/engine.mjs';
+
+const LIB = '0603 buildEstimateQuery.mjs';
+console.log(`${LIB}: starting.`);
+
+const assertions = [];
+
+function makeAccumulator(overrides = {}) {
+  return {
+    constraints: [],
+    _initialConstraintCount: 0,
+    ctsConstraints: [cts.trueQuery()],
+    conjunctionJoins: [],
+    andOrSubPlans: [],
+    patternJoins: [],
+    ...overrides,
+  };
+}
+
+const scenarios = [
+  {
+    name: 'returns null when acc has conjunctionJoins',
+    acc: makeAccumulator({ conjunctionJoins: [{ type: 'joinInner' }] }),
+    assemblyContext: { logicType: 'and' },
+    scope: 'item',
+    expected: { isNull: true },
+  },
+  {
+    name: 'returns null when acc has patternJoins',
+    acc: makeAccumulator({ patternJoins: [{ right: {}, on: [] }] }),
+    assemblyContext: { logicType: 'and' },
+    scope: 'item',
+    expected: { isNull: true },
+  },
+  {
+    name: 'returns null when acc has no ctsConstraints',
+    acc: makeAccumulator({ ctsConstraints: [] }),
+    assemblyContext: { logicType: 'and' },
+    scope: 'item',
+    expected: { isNull: true },
+  },
+  {
+    name: 'returns CTS query for join-free AND accumulator with item scope',
+    acc: makeAccumulator({
+      ctsConstraints: [cts.fieldWordQuery('itemAnyText', 'blue')],
+    }),
+    assemblyContext: { logicType: 'and' },
+    scope: 'item',
+    expected: {
+      isNull: false,
+      contains: ['fieldWordQuery', 'fieldValueQuery', 'anyDataTypeName'],
+    },
+  },
+  {
+    name: 'returns CTS query for join-free OR accumulator with agent scope',
+    acc: makeAccumulator({
+      ctsConstraints: [
+        cts.fieldWordQuery('agentPrimaryName', 'john'),
+        cts.fieldWordQuery('agentPrimaryName', 'doe'),
+      ],
+    }),
+    assemblyContext: { logicType: 'or' },
+    scope: 'agent',
+    expected: {
+      isNull: false,
+      contains: ['orQuery', 'fieldValueQuery', 'anyDataTypeName'],
+    },
+  },
+  {
+    name: 'includes scope dataType filter for work scope',
+    acc: makeAccumulator({
+      ctsConstraints: [cts.fieldWordQuery('workAnyText', 'painting')],
+    }),
+    assemblyContext: { logicType: 'and' },
+    scope: 'work',
+    expected: {
+      isNull: false,
+      contains: ['anyDataTypeName', 'LinguisticObject'],
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  const result = buildEstimateQuery(
+    scenario.acc,
+    scenario.assemblyContext,
+    scenario.scope,
+  );
+
+  if (scenario.expected.isNull) {
+    assertions.push(
+      testHelperProxy.assertEqual(
+        null,
+        result,
+        `Scenario '${scenario.name}': expected null, got ${typeof result}`,
+      ),
+    );
+  } else {
+    assertions.push(
+      testHelperProxy.assertTrue(
+        result != null,
+        `Scenario '${scenario.name}': expected non-null CTS query`,
+      ),
+    );
+
+    if (scenario.expected.contains) {
+      const serialized = xdmp.quote(result);
+      for (const text of scenario.expected.contains) {
+        assertions.push(
+          testHelperProxy.assertTrue(
+            serialized.includes(text),
+            `Scenario '${scenario.name}': serialized query should contain '${text}'`,
+          ),
+        );
+      }
+    }
+  }
+}
+
+console.log(
+  `${LIB}: completed ${assertions.length} assertions from ${scenarios.length} scenarios.`,
+);
+
+assertions;
+export default assertions;


### PR DESCRIPTION
More CTS in Optic via:

1. Introduce the CTS Estimate which uses `cts.estimate` and `plan.offset().limit()` to applicable search requests vs. materializing all of a search's rows just to get the total.
2. Modify qualifying patterns to only contribute to `ctsConstraints`, thereby increasing the CTS Fold and CTS Estimate optimization eligibility to more searches.