### PR TITLE
Opt 24: utilize CTS optimizations when possible within Hop Inverse

### DIFF
--- a/docs/lux-optic-primer.md
+++ b/docs/lux-optic-primer.md
@@ -147,6 +147,13 @@
     - [Constraints](#constraints-1)
     - [Open question](#open-question)
     - [Next step](#next-step)
+  - [Optimization 24: HopInverse CTS fast path](#optimization-24-hopinverse-cts-fast-path)
+    - [Problem](#problem-6)
+    - [Why HopInverse cannot use cts.tripleRangeQuery](#why-hopinverse-cannot-use-ctstriplerangequery)
+    - [Approach](#approach-2)
+    - [Implementation](#implementation-1)
+    - [Benchmark](#benchmark-1)
+    - [Scope and limitations](#scope-and-limitations)
 
 # Introduction
 
@@ -1116,6 +1123,7 @@ Performance opportunities that could be implemented above the backend (mostly).
 | 9 | [Opt 20](#optimization-20-eliminate-fromlexicons-for-join-free-queries) | avoidLexicons: replace `fromLexicons` with `op.fromSearch` + `joinDocAndUri` after pagination. For the reference query, this optimization eliminated 3 lexicon scans (43.9M entries each) and dedup groupBy. Mean dropped from 231% to 31% of CTS (3.2× faster). | 2026-06-28 |
 | 10 | [Opt 22](#optimization-22-anntopk-post-filter-for-hnsw-index-usage) | annTopK post-filter: move scope/self-exclusion filters to after `annTopK` so the HNSW index is used (`indexed="true"`). Pre-filters caused brute-force kNN — 800× slower on 20M vectors. Also extends Opt 20 to skip `fromLexicons` for annTopK-only queries. | 2026-06-29 |
 | 11 | [Opt 21](#optimization-21-cts-native-facet-computation) | CTS-native facet computation: three-way dispatch in `calculateFacets`. Semantic facets use CTS enumerate + estimate (1,044× faster than Optic triple joins at 2.5M scale). Non-semantic facets use `op.fromSearch(scopedCtsQuery)` (32× faster than URI-list approach). Removes facet guard from `isCtsExecutionEligible`, enabling Opt 18/20 when facets are co-requested. Depends on [Opt 15](#optimization-15-cts-fold). | 2026-07-02 |
+| 12 | [Opt 24](#optimization-24-hopinverse-cts-fast-path) | HopInverse CTS fast path: when inner criteria resolves to pure CTS, apply `.where(innerCts)` directly on `fromTriples` instead of building a `fromLexicons` plan and fragment-joining. Eliminates per-hop IRI lexicon scans (~43.9M rows). Representative query: 2,649ms → 121ms (22×). | 2026-07-05 |
 
 ## Data Type Constraint Optimizations
 
@@ -2056,3 +2064,117 @@ Whether MarkLogic physically materializes a separate HNSW graph per QBV (true pa
 ### Next step
 
 Test `annTopK` against a QBV (e.g., filtered by collection) to determine whether `plan:ann-result indexed="true"` still fires and whether timing improves versus the base view with post-filter.
+
+## Optimization 24: HopInverse CTS fast path
+
+**Status:** Implemented.
+
+**Prerequisite:** [Opt 15 (CTS Fold)](#optimization-15-cts-fold) must be in place — the fold mechanism is what makes inner criteria produce pure-CTS accumulators. [Opt 16 (HopWithField CTS)](#optimization-16-hopwithfield-cts) provides the analogous optimization for `hopWithField` terms; Opt 24 extends the same principle to `hopInverse`.
+
+### Problem
+
+Multi-hop `hopInverse` queries are dominated by intermediate `fromLexicons` scans. Each hop level builds a nested plan via `processNestedCriteria`, which always creates a `fromLexicons({uri, iri, dataType})` plan as the row source. For a 2-hop query like `curated.containingItem.id`, this produces two intermediate `fromLexicons` scans in addition to the top-level scan — each scanning up to 43.9M IRI entries from the lexicon index.
+
+Representative query (`searchWillMatch` for `lux:itemDepartment`):
+```json
+{"curated": {"containingItem": {"id": "https://lux.collections.yale.edu/data/object/..."}}}
+```
+
+Before Opt 24, the plan for this query:
+```javascript
+// Top-level: agent scope
+op.fromLexicons({uri, iri, dataType}).where(dataType in ['Person','Group'])
+  .joinInner(
+    // Outer triple (agentOfCuration)
+    op.fromTriples([pattern(s, agentOfCuration, o, triFrag)])
+      .joinInner(
+        // INTERMEDIATE: set scope — 316K-row lexicon scan
+        op.fromLexicons({set_uri, set_iri, set_dataType}).where(dataType='Set')
+          .joinInner(
+            // Inner triple (member_of)
+            op.fromTriples([pattern(s, member_of, o, triFrag)])
+              .joinInner(
+                // INTERMEDIATE: item scope — 10M+ row lexicon scan
+                op.fromLexicons({item_uri, item_iri, item_dataType})
+                  .where(dataType in ['DigitalObject','HumanMadeObject'])
+                  .where(cts.documentQuery(targetId))
+                  .select([item_iri, item_frag]),     // Opt 17 barrier
+                on(triFrag, item_frag)),              // fragment join
+            on(set_iri, inner_o))
+          .select([set_iri, set_frag]),               // Opt 17 barrier
+        on(triFrag, set_frag)),                       // fragment join
+    on(iri, outer_o))
+```
+
+The two intermediate `fromLexicons` calls — scanning 10M+ and 316K rows respectively — are pure overhead. Their only purpose is to provide an `iri` column and `frag` column for the hop pattern joins, but the `fromTriples` pattern already provides equivalent columns via its subject/object and fragmentIdCol.
+
+### Why HopInverse cannot use cts.tripleRangeQuery
+
+[Opt 16](#optimization-16-hopwithfield-cts) resolves `hopWithField` terms as `cts.tripleRangeQuery` CTS constraints. This works because `hopWithField`'s triple `(parent, predicate, child)` lives on the **parent** document — the one being constrained. `cts.tripleRangeQuery` matches documents containing the specified triple, so the constraint correctly filters the parent scope.
+
+`hopInverse` has the opposite triple direction: `(child, predicate, parent)` where the triple lives on the **child** (referenced) document, not the parent. `cts.tripleRangeQuery` would constrain child documents, not the parent scope the search needs to filter. This means HopInverse cannot fully collapse to a CTS constraint and must retain an Optic `fromTriples` row source to bridge the document boundary.
+
+### Approach
+
+When HopInverse's inner criteria resolves to pure CTS (detected via `processNestedCriteriaAsCts`), apply the CTS query as `.where(innerCts)` directly on the `fromTriples` plan instead of building a separate `fromLexicons` plan and fragment-joining.
+
+After Opt 24, the innermost hop in the example above becomes:
+```javascript
+// Inner triple — no fromLexicons, no fragment join
+op.fromTriples([pattern(s, member_of, o, triFrag)])
+  .where(cts.documentQuery(targetId))       // CTS applied directly
+```
+
+The `.where()` on `fromTriples` constrains which document fragments the triples come from — functionally equivalent to the fragment join against `fromLexicons.where(ctsQuery)`, but without the lexicon scan.
+
+### Implementation
+
+Single change in `HopInverse.mjs` — `apply()` method. Before building the Optic fallback path (`fromTriples.joinInner(processNestedCriteria(...))`), attempt `processNestedCriteriaAsCts`:
+
+```javascript
+const innerCts = scp.processNestedCriteriaAsCts({
+  planCriteria: searchTerm.getCriteria(),
+  planScope: termConfig.getTargetScopeName(),
+  patternOptions: SCP.initializePatternOptions(),
+  parentId: id,
+});
+if (innerCts) {
+  return {
+    patternJoins: [{
+      right: tri.where(innerCts),
+      on: op.on(op.col(parentIriCol), op.col(id + '_o')),
+      extraCols: [],
+    }],
+  };
+}
+```
+
+When `processNestedCriteriaAsCts` returns non-null:
+- The `fromTriples` plan gets a `.where(innerCts)` constraint — no `fromLexicons` needed.
+- The fragment join (`on(triFrag, refFrag)`) is eliminated — the `.where()` directly constrains the triple's source fragments.
+- The outer join key remains `on(parentIriCol, _o)` — unchanged from the original path.
+
+When `processNestedCriteriaAsCts` returns null (inner criteria requires Optic joins), the existing `processNestedCriteria` fallback path fires unchanged.
+
+**Source file:** `src/main/ml-modules/root/lib/search/patterns/HopInverse.mjs`
+
+### Benchmark
+
+Representative query: `{"curated":{"containingItem":{"id":"..."}}}` via `searchWillMatch`.
+
+| Metric | Before Opt 24 | After Opt 24 | Improvement |
+|---|---|---|---|
+| `lux:itemDepartment` latency | 2,649ms | 121ms | 22× |
+| Total batch (6 searches) | 3,127ms | 603ms | 5.2× |
+
+### Scope and limitations
+
+**What Opt 24 covers:**
+- Any `hopInverse` term whose inner criteria resolves to pure CTS via `processNestedCriteriaAsCts`. This includes direct IRI lookups (`{id: "..."}`, `{iri: "..."}`), field constraints (`{name: "..."}`, `{identifier: "..."}`), and nested criteria composed entirely of CTS-foldable terms.
+
+**What Opt 24 does not cover:**
+- Inner criteria requiring Optic joins (e.g., nested hops that themselves don't resolve to CTS). These fall back to the original `processNestedCriteria` + `fromLexicons` path.
+
+**Cascade behavior:** Opt 24 returns `patternJoins` (not `ctsConstraints`), so it does not cascade through `processNestedCriteriaAsCts` at the parent scope level. For a 2-hop chain like `curated.containingItem.id`, the innermost `fromLexicons` (item scope, ~10M rows) is eliminated, but the middle `fromLexicons` (set scope, ~316K rows) is retained. Despite this single-level limitation, the benchmark shows the optimization is sufficient for the target query shape.
+
+**Relationship to Opt 16:** Opt 16 handles `hopWithField` by emitting `cts.tripleRangeQuery` as a `ctsConstraint`, which DOES cascade — each outer hop also sees only CTS and can resolve without Optic. Opt 24 handles `hopInverse` via a different mechanism (`.where()` on `fromTriples`) because the triple's document location prevents full CTS resolution. The two optimizations are complementary and cover the two hop pattern types.

--- a/docs/lux-optic-primer.md
+++ b/docs/lux-optic-primer.md
@@ -127,7 +127,7 @@
     - [Validation results](#validation-results)
       - [Non-semantic facets (`itemTypeId`, 55K matches, `cts.fieldWordQuery('itemAnyText', 'painting')`)](#non-semantic-facets-itemtypeid-55k-matches-ctsfieldwordqueryitemanytext-painting)
       - [Semantic facets (`responsibleCollections`, 2.5M matches)](#semantic-facets-responsiblecollections-25m-matches)
-      - [Performance test results](#performance-test-results)
+      - [Performance test results (2026-07-03)](#performance-test-results-2026-07-03)
     - [Implementation](#implementation)
       - [`performSearch` execution paths (engine.mjs)](#performsearch-execution-paths-enginemjs)
       - [`calculateFacets` dispatch (calculateFacets.mjs)](#calculatefacets-dispatch-calculatefacetsmjs)
@@ -153,6 +153,8 @@
     - [Approach](#approach-2)
     - [Implementation](#implementation-1)
     - [Benchmark](#benchmark-1)
+      - [Single query](#single-query)
+      - [10k performance test (2026-07-05)](#10k-performance-test-2026-07-05)
     - [Scope and limitations](#scope-and-limitations)
 
 # Introduction
@@ -1874,9 +1876,22 @@ Benchmarked on MarkLogic 12.0.1 against the content database. Scripts in `scratc
 
 5. **`responsibleUnits`** has a 3-hop chain with no single denormalized field equivalent. Its CTS config uses `cts.triples` + `cts.documentQuery` nesting to pre-compute candidates — manageable because the enumeration runs once (search-independent) and per-value `cts.estimate` calls use the same field-index intersection pattern.
 
-#### Performance test results
+#### Performance test results (2026-07-03)
 
-TODO: Add 10k performance test results comparing pre-Opt-21 baselines (IDs 22, 26, 30) against Opt 21 enabled.
+Results are of the 19,626 derived facet requests from the 10k-1 search requests.  CTS baseline: 7/2 CTS New 10k-1 with warm caches (14 min). Optic stack: 1, 3, 15, 17, 18, 20, 22 (ID 22, w/o Opt 21) and + 21 (IDs 31/32, w/ Opt 21).
+
+Comparison 22 → 31: adding Opt 21 (Optic-to-Optic).
+
+| Metric | ID 22 (w/o Opt 21) | ID 31 (w/ Opt 21) | Change |
+|---|---|---|---|
+| Test duration | 59 min | 42 min | −29% |
+| Mean (% of CTS) | 290.90% | 203.90% | −22.3% (Optic-to-Optic) |
+| p99.9 (% of CTS) | 71.70% | 2.10% | 1.7× slower → **near parity** |
+| Slowest 20 range (ms) | 7,401–20,158 | 2,319–10,228 | |
+| Requests > 1s | 20 | 20 | unchanged |
+| Functional diff vs CTS | 4,701 | 4,680 | −21 |
+
+Opt 21 substantially improved tail latency: p99.9 dropped from 71.7% above CTS to 2.1% — near parity. The slowest 20 range narrowed from 7.4–20.2s to 2.3–10.2s. However, mean latency remained 2× above CTS (203.9%), and both Optic and CTS had 20 requests over 1s (CTS range: 1,286–3,319ms). The mean gap reflects searches where Opt 21 does not fire (hop/join queries that fall back to Path 3 URI-list facets).
 
 ### Implementation
 
@@ -2160,12 +2175,31 @@ When `processNestedCriteriaAsCts` returns null (inner criteria requires Optic jo
 
 ### Benchmark
 
+#### Single query
+
 Representative query: `{"curated":{"containingItem":{"id":"..."}}}` via `searchWillMatch`.
 
 | Metric | Before Opt 24 | After Opt 24 | Improvement |
 |---|---|---|---|
 | `lux:itemDepartment` latency | 2,649ms | 121ms | 22× |
 | Total batch (6 searches) | 3,127ms | 603ms | 5.2× |
+
+#### 10k performance test (2026-07-05)
+
+10K-document `get-data-no-profile` requests, cleared caches. CTS baseline: 7/4 CTS 10k-docs-no-pro (20 min). Optic stack: 1, 3, 15, 17, 18, 20, 21, 22 (ID 35) + 24 (ID 36).
+
+Before Opt 24 (ID 35), `lux:itemDepartment` (a 2-hop `hopInverse` chain) was the slowest search at 2.9–3.1s (CTS: 522–780ms). All but one of the 20 slowest were item-scope.
+
+Comparison 35 → 36: adding Opt 24.
+
+| Metric | ID 35 (w/o Opt 24) | ID 36 (w/ Opt 24) | Change |
+|---|---|---|---|
+| Test duration | 300 min | 66 min | −78% |
+| Mean (% of CTS) | 1,409.90% | 232.50% | 14× slower → **2.3× slower** |
+| p99.9 (% of CTS) | 662.90% | 46.10% | 6.6× slower → **2.2× faster** |
+| Slowest 20 range (ms) | 4,313–18,403 | 817–1,064 | |
+| Requests > 1s | 20 | 1 | −95% |
+| Functional diff vs CTS | 39 | 38 | −1 |
 
 ### Scope and limitations
 

--- a/src/main/ml-modules/root/lib/search/patterns/HopInverse.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/HopInverse.mjs
@@ -26,13 +26,6 @@ class HopInverse extends SearchPatternBase {
       return this.#processValuesOnly(scp, searchTerm, patternOptions);
     }
 
-    // TODO, PERF: Potential optimization.  When the child criteria is a literal IRI
-    // (same condition #processValuesOnly checks), both hops could be resolved via
-    // cts.triples and injected as op.fromLiterals, avoiding the inner
-    // processNestedCriteria call.  This path only compiles one plan, but it could
-    // still matter for latency-sensitive queries.  Consider prototyping if
-    // profiling shows the inner plan construction is a bottleneck.
-
     const tri = op.fromTriples([
       op.pattern(
         op.col(id + '_s'),
@@ -42,6 +35,29 @@ class HopInverse extends SearchPatternBase {
       ),
     ]);
 
+    // Opt 24: when inner criteria resolves to pure CTS, apply it as .where()
+    // directly on fromTriples instead of building a fromLexicons plan and
+    // joining on fragment. Eliminates the intermediate IRI lexicon scan
+    // (~43.9M rows) that dominates multi-hop query cost.
+    const innerCts = scp.processNestedCriteriaAsCts({
+      planCriteria: searchTerm.getCriteria(),
+      planScope: termConfig.getTargetScopeName(),
+      patternOptions: SCP.initializePatternOptions(),
+      parentId: id,
+    });
+    if (innerCts) {
+      return {
+        patternJoins: [
+          {
+            right: tri.where(innerCts),
+            on: op.on(op.col(parentIriCol), op.col(id + '_o')),
+            extraCols: [],
+          },
+        ],
+      };
+    }
+
+    // Fallback: Optic join path (when inner criteria requires joins).
     const right = tri.joinInner(
       scp.processNestedCriteria({
         planCriteria: searchTerm.getCriteria(),

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/1030 HopInverse-ctsFastPath.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/1030 HopInverse-ctsFastPath.mjs
@@ -1,0 +1,221 @@
+/**
+ * Tests HopInverse.apply() Opt 24 CTS fast path.
+ *
+ * When inner criteria resolves to pure CTS (processNestedCriteriaAsCts
+ * returns non-null), HopInverse applies .where(innerCts) directly on
+ * fromTriples instead of building a fromLexicons plan and fragment-joining.
+ *
+ * Does not execute searches against the content database.
+ */
+
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { executeScenario } from '/test/unitTestUtils.mjs';
+import { SearchPatternBase } from '/lib/search/patterns/SearchPatternBase.mjs';
+import { PatternOptions } from '/lib/search/PatternOptions.mjs';
+import '/lib/search/patterns/HopInverse.mjs';
+import op from '/MarkLogic/optic.mjs';
+
+const LIB = '1030 HopInverse-ctsFastPath.mjs';
+console.log(`${LIB}: starting.`);
+
+let assertions = [];
+
+const pattern = SearchPatternBase.get('hopInverse');
+
+const MOCK_PREDICATES = ['la:member_of'];
+const MOCK_TARGET_SCOPE = 'item';
+const MOCK_ID = 'containingItem';
+const MOCK_PARENT_IRI_COL = 'set_iri';
+const MOCK_CRITERIA = {
+  id: 'https://lux.collections.yale.edu/data/object/mock-id',
+};
+const MOCK_CTS_QUERY = cts.documentQuery(MOCK_CRITERIA.id);
+
+function mockSearchTerm() {
+  return {
+    getId: () => MOCK_ID,
+    getParentIriColumn: () => MOCK_PARENT_IRI_COL,
+    getCriteria: () => MOCK_CRITERIA,
+    isTopLevel: () => false,
+    getSearchTermConfig: () => ({
+      getPredicates: () => MOCK_PREDICATES,
+      getTargetScopeName: () => MOCK_TARGET_SCOPE,
+    }),
+  };
+}
+
+function mockPatternOptions() {
+  return new PatternOptions();
+}
+
+// SCP mock where processNestedCriteriaAsCts returns a CTS query (fast path).
+function mockScpWithCts() {
+  return {
+    processNestedCriteriaAsCts: () => MOCK_CTS_QUERY,
+    processNestedCriteria: () => {
+      throw new Error(
+        'processNestedCriteria should not be called on CTS fast path',
+      );
+    },
+  };
+}
+
+// SCP mock where processNestedCriteriaAsCts returns null (fallback path).
+function mockScpFallback() {
+  // processNestedCriteria returns a minimal plan with iri + frag columns.
+  const nestedPlan = op
+    .fromLexicons(
+      { [MOCK_ID + '_iri']: cts.iriReference() },
+      null,
+      op.fragmentIdCol(MOCK_ID + '_frag'),
+    )
+    .select([MOCK_ID + '_iri', MOCK_ID + '_frag']);
+  return {
+    processNestedCriteriaAsCts: () => null,
+    processNestedCriteria: () => nestedPlan,
+  };
+}
+
+const scenarios = [
+  // --- CTS fast path (Opt 24) ---
+  {
+    name: 'CTS fast path: plan uses fromTriples with .where(), no fromLexicons',
+    input: { scp: mockScpWithCts() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      planContains: ['fromTriples', 'member_of', 'documentQuery'],
+      planExcludes: ['fromLexicons'],
+    },
+  },
+  {
+    name: 'CTS fast path: no fragment join columns in the plan',
+    input: { scp: mockScpWithCts() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      // Fragment join uses on(triFrag, refFrag) — with CTS fast path,
+      // neither column name pattern should appear in a join context.
+      planExcludes: ['fromLexicons', MOCK_ID + '_frag'],
+    },
+  },
+  {
+    name: 'CTS fast path: outer join key uses parent IRI and triple object',
+    input: { scp: mockScpWithCts() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      joinOnContains: [MOCK_PARENT_IRI_COL, MOCK_ID + '_o'],
+    },
+  },
+
+  // --- Fallback path (processNestedCriteriaAsCts returns null) ---
+  {
+    name: 'Fallback: plan uses fromTriples joined to fromLexicons via fragment',
+    input: { scp: mockScpFallback() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      planContains: ['fromTriples', 'fromLexicons', 'member_of'],
+      planExcludes: ['documentQuery'],
+    },
+  },
+  {
+    name: 'Fallback: plan includes fragment join columns',
+    input: { scp: mockScpFallback() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      planContains: [MOCK_ID + '_triFrag', MOCK_ID + '_frag'],
+    },
+  },
+  {
+    name: 'Fallback: outer join key unchanged from CTS path',
+    input: { scp: mockScpFallback() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      joinOnContains: [MOCK_PARENT_IRI_COL, MOCK_ID + '_o'],
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  const zeroArityFun = () => {
+    return pattern.apply(
+      scenario.input.scp,
+      mockSearchTerm(),
+      'and',
+      mockPatternOptions(),
+    );
+  };
+
+  const scenarioResults = executeScenario(scenario, zeroArityFun);
+
+  if (scenarioResults.applyErrorNotExpectedAssertions) {
+    const result = scenarioResults.actualValue;
+    const e = scenario.expected;
+    const p = scenario.name;
+
+    if (e.hasPatternJoins) {
+      assertions.push(
+        testHelperProxy.assertTrue(
+          result &&
+            Array.isArray(result.patternJoins) &&
+            result.patternJoins.length > 0,
+          `${p}: should return patternJoins`,
+        ),
+      );
+    }
+
+    if (result && result.patternJoins && result.patternJoins.length > 0) {
+      const pj = result.patternJoins[0];
+      const planSource = op.toSource(pj.right.export());
+
+      if (e.planContains) {
+        for (const text of e.planContains) {
+          assertions.push(
+            testHelperProxy.assertTrue(
+              typeof planSource === 'string' && planSource.includes(text),
+              `${p}: plan should contain '${text}'`,
+            ),
+          );
+        }
+      }
+
+      if (e.planExcludes) {
+        for (const text of e.planExcludes) {
+          assertions.push(
+            testHelperProxy.assertFalse(
+              typeof planSource === 'string' && planSource.includes(text),
+              `${p}: plan should NOT contain '${text}'`,
+            ),
+          );
+        }
+      }
+
+      if (e.joinOnContains) {
+        const joinOnSource = JSON.stringify(pj.on);
+        for (const text of e.joinOnContains) {
+          assertions.push(
+            testHelperProxy.assertTrue(
+              typeof joinOnSource === 'string' && joinOnSource.includes(text),
+              `${p}: join on should contain '${text}'`,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  if (scenarioResults.assertions.length > 0) {
+    assertions = assertions.concat(scenarioResults.assertions);
+  }
+}
+
+console.log(
+  `${LIB}: completed ${assertions.length} assertions from ${scenarios.length} scenarios.`,
+);
+
+assertions;
+export default assertions;


### PR DESCRIPTION
HopInverse CTS fast path: when inner criteria resolves to pure CTS, apply .where(innerCts) directly on fromTriples instead of building a fromLexicons plan and fragment-joining. Eliminates per-hop IRI lexicon scans (~43.9M rows). Representative query: 2,649ms → 121ms (22×).