### PR TITLE
Opt 21: facet optimization (plus Opt 24)

### DIFF
--- a/docs/lux-optic-primer.md
+++ b/docs/lux-optic-primer.md
@@ -122,18 +122,17 @@
       - [Prototype (single query, MarkLogic 12.0.1)](#prototype-single-query-marklogic-1201)
       - [10k-3 performance test (2026-06-28, commit 2211d13)](#10k-3-performance-test-2026-06-28-commit-2211d13)
     - [Relationship to other optimizations](#relationship-to-other-optimizations)
-  - [Optimization 21: Eliminate URI-list materialization for facets](#optimization-21-eliminate-uri-list-materialization-for-facets)
+  - [Optimization 21: CTS-native facet computation](#optimization-21-cts-native-facet-computation)
     - [Problem](#problem-3)
-    - [Approach](#approach-1)
-    - [Eligibility](#eligibility-1)
-    - [Implementation plan](#implementation-plan)
-      - [1. Modify `calculateFacets` to accept an optional CTS query](#1-modify-calculatefacets-to-accept-an-optional-cts-query)
-      - [2. Modify `performSearch` to pass `scopedCtsQuery` to `calculateFacets`](#2-modify-performsearch-to-pass-scopedctsquery-to-calculatefacets)
-      - [3. Handle `rows = null` in `calculateFacets`](#3-handle-rows--null-in-calculatefacets)
-      - [4. Verify correctness](#4-verify-correctness)
-    - [What this does NOT address](#what-this-does-not-address-1)
-    - [Relationship to other optimizations](#relationship-to-other-optimizations-1)
-    - [Estimated impact](#estimated-impact)
+    - [Validation results](#validation-results)
+      - [Non-semantic facets (`itemTypeId`, 55K matches, `cts.fieldWordQuery('itemAnyText', 'painting')`)](#non-semantic-facets-itemtypeid-55k-matches-ctsfieldwordqueryitemanytext-painting)
+      - [Semantic facets (`responsibleCollections`, 2.5M matches)](#semantic-facets-responsiblecollections-25m-matches)
+      - [Performance test results](#performance-test-results)
+    - [Implementation](#implementation)
+      - [`performSearch` execution paths (engine.mjs)](#performsearch-execution-paths-enginemjs)
+      - [`calculateFacets` dispatch (calculateFacets.mjs)](#calculatefacets-dispatch-calculatefacetsmjs)
+      - [Semantic facet configuration (semanticFacetsConfig.mjs)](#semantic-facet-configuration-semanticfacetsconfigmjs)
+      - [Source files](#source-files)
   - [Optimization 22: annTopK post-filter for HNSW index usage](#optimization-22-anntopk-post-filter-for-hnsw-index-usage)
     - [Problem](#problem-4)
     - [Root cause](#root-cause)
@@ -144,7 +143,7 @@
     - [Additional engine optimization](#additional-engine-optimization)
   - [Optimization 23: Scope-specific QBVs for annTopK graph partitioning](#optimization-23-scope-specific-qbvs-for-anntopk-graph-partitioning)
     - [Problem](#problem-5)
-    - [Approach](#approach-2)
+    - [Approach](#approach-1)
     - [Constraints](#constraints-1)
     - [Open question](#open-question)
     - [Next step](#next-step)
@@ -1116,6 +1115,7 @@ Performance opportunities that could be implemented above the backend (mostly).
 | 8 | [Opt 18](#optimization-18-ctsestimate-with-offsetlimit-for-join-free-queries) | cts.estimate with offset/limit: when CTS Fold ([Opt 15](#optimization-15-cts-fold)) is applicable, use `cts.estimate` for total count and `.offset().limit()` for the requested page's results. Avoids materializing all rows. | 2026-06-26 |
 | 9 | [Opt 20](#optimization-20-eliminate-fromlexicons-for-join-free-queries) | avoidLexicons: replace `fromLexicons` with `op.fromSearch` + `joinDocAndUri` after pagination. For the reference query, this optimization eliminated 3 lexicon scans (43.9M entries each) and dedup groupBy. Mean dropped from 231% to 31% of CTS (3.2× faster). | 2026-06-28 |
 | 10 | [Opt 22](#optimization-22-anntopk-post-filter-for-hnsw-index-usage) | annTopK post-filter: move scope/self-exclusion filters to after `annTopK` so the HNSW index is used (`indexed="true"`). Pre-filters caused brute-force kNN — 800× slower on 20M vectors. Also extends Opt 20 to skip `fromLexicons` for annTopK-only queries. | 2026-06-29 |
+| 11 | [Opt 21](#optimization-21-cts-native-facet-computation) | CTS-native facet computation: three-way dispatch in `calculateFacets`. Semantic facets use CTS enumerate + estimate (1,044× faster than Optic triple joins at 2.5M scale). Non-semantic facets use `op.fromSearch(scopedCtsQuery)` (32× faster than URI-list approach). Removes facet guard from `isCtsExecutionEligible`, enabling Opt 18/20 when facets are co-requested. Depends on [Opt 15](#optimization-15-cts-fold). | 2026-07-02 |
 
 ## Data Type Constraint Optimizations
 
@@ -1605,8 +1605,9 @@ The logic of when cts.estimate with offset/limit applies is defined in [engine.m
 1. **The top-level accumulator is join-free** (`isAccumulatorJoinFree`): no `patternJoins`, no `andOrSubPlans`, no `conjunctionJoins`, at least one `ctsConstraint`, and no pattern-added Optic `constraints` beyond the initial dataType constraint.
 2. **The request includes search results** (`includeSearchResults` is true). Facet-only requests take a different path.
 3. **No `pageWith`** is requested. `pageWith` requires locating a specific document's position in the full result set.
-4. **No facet requests.** Facets require aggregation over the full result set.
-5. **`buildScopedCtsQuery` returns non-null.** This composes the CTS query with a scope dataType filter (`cts.fieldValueQuery('anyDataTypeName', scopeTypes)`) so cross-scope fields like `anyAnyText` don't overcount.
+4. **`buildScopedCtsQuery` returns non-null.** This composes the CTS query with a scope dataType filter (`cts.fieldValueQuery('anyDataTypeName', scopeTypes)`) so cross-scope fields like `anyAnyText` don't overcount.
+
+*Note:* The original implementation also required no facet requests. [Opt 21](#optimization-21-cts-native-facet-computation) removed that guard — `calculateFacets` now works directly with `scopedCtsQuery`, so facets are compatible with the CTS execution path.
 
 ### Pattern CTS Conversions
 
@@ -1735,8 +1736,7 @@ Same as `isCtsExecutionEligible` (Opt 18) — all of the following must be true:
 1. Top-level accumulator is join-free (`isAccumulatorJoinFree`).
 2. Request includes search results (`includeSearchResults`).
 3. No `pageWith` requested.
-4. No facet requests.
-5. `buildScopedCtsQuery` returns non-null.
+4. `buildScopedCtsQuery` returns non-null.
 
 When these hold, no pattern needs the `iri`, `uri`, or `dataType` lexicon columns for joins. The only purpose of `fromLexicons` is to produce `{id, type}` output rows — which `fromSearch` + `joinDocAndUri` achieves without scanning any lexicons.
 
@@ -1757,7 +1757,7 @@ Key decisions: `scopedCtsQuery` (includes scope dataType filter) prevents cross-
 - **annTopK queries.** The `annTopK` pattern contributes `patternJoins`, which causes `isAccumulatorJoinFree()` to return false and `buildScopedCtsQuery()` to return null. Opt 20's `fromSearch` path is therefore ineligible. However, the **Opt 20 extension** ([Opt 22 — Additional engine optimization](#additional-engine-optimization)) provides an analogous bypass specifically for annTopK-only queries: `getDirectPlan()` detects the single-annTopK accumulator and uses the TDE view's `{uri, dataType}` columns directly, eliminating `fromLexicons` without requiring `fromSearch`. This path is complementary — it fires when Opt 20 cannot.
 - **Keyword search cold-start.** The keyword pattern's 49K-IRI `cts.tripleRangeQuery` still produces a large CTS query object. `fromSearch` with that query still requires the optimizer to process the AST. However, the `fromSearch` plan is structurally simpler (no lexicon joins, no groupBy), so the optimizer cost may be lower — worth measuring.
 - **Non-relevance sort.** Field-based sorts require lexicon columns. V1 restricts to relevance sort.
-- **Facets, pageWith.** Excluded by `isCtsExecutionEligible` eligibility.
+- **`pageWith`.** Excluded by `isCtsExecutionEligible` eligibility.
 
 ### Benchmark
 
@@ -1801,13 +1801,20 @@ The mean result is the headline: Optic went from 2.3× slower than CTS to 3.2× 
 ### Relationship to other optimizations
 
 - **Opt 18 (cts.estimate with offset/limit):** Prerequisite. Opt 20 extends Opt 18 by also eliminating the Optic plan for the page results, not just the total count.
+- **Opt 21 (CTS-native facet computation):** Complementary. Opt 21 removed the facet-request guard from `isCtsExecutionEligible`, so Opt 20 now fires even when facets are co-requested with search results. Opt 20 handles the page; Opt 21 handles the facets.
 - **Opt 22 (annTopK post-filter):** The Opt 20 extension for annTopK is implemented as part of Opt 22. When annTopK is the sole criterion, `getDirectPlan()` bypasses `fromLexicons` using the TDE view directly — analogous to Opt 20's `fromSearch` bypass for CTS-foldable queries, but for a different eligibility condition (`annTopKSelfSufficient` flag vs `isAccumulatorJoinFree`).
 - **Opt 5 (Remove `iri` from `fromLexicons`):** Complementary but subsumed for eligible queries. Opt 5 would still help queries that use `fromLexicons` but don't need `iri` (e.g., non-relevance-sorted join-free queries). If Opt 20 is implemented first, Opt 5's remaining value is limited to the non-Opt-20-eligible subset.
 - **Opt 14 (Page-Slice, abandoned):** Opt 20 is structurally similar — both bypass `fromLexicons` for page results and use CTS for pagination. The key differences: Opt 20 uses `op.fromSearch` (stays within Optic's API), has a well-defined eligibility gate (`isCtsExecutionEligible`), and does not introduce a separate `cts.search` code path. The total-count concern that killed Opt 14 does not apply — Opt 18's `cts.estimate` with scope filter is already validated.
 
-## Optimization 21: Eliminate URI-list materialization for facets
+## Optimization 21: CTS-native facet computation
 
-**Status:** Validated — implementation pending.
+**Status:** Implemented.
+
+**Depends on:** [Opt 15 (CTS Fold)](#optimization-15-cts-fold) — produces the `scopedCtsQuery` that gates Paths 1 and 2.
+
+**Enables:** Removes the facet-request guard from `isCtsExecutionEligible`, allowing [Opt 18](#optimization-18-ctsestimate-with-offsetlimit-for-join-free-queries) and [Opt 20](#optimization-20-eliminate-fromlexicons-for-join-free-queries) to fire even when facets are co-requested with search results.
+
+**Complements:** [Opt 18](#optimization-18-ctsestimate-with-offsetlimit-for-join-free-queries) (total count) and [Opt 20](#optimization-20-eliminate-fromlexicons-for-join-free-queries) (page results). When all three fire together, no full materialization is needed for join-free queries — even with facets.
 
 ### Problem
 
@@ -1835,7 +1842,7 @@ Benchmarked on MarkLogic 12.0.1 against the content database. Scripts in `scratc
 | A: `op.fromSearch(cts.documentQuery(uriList))` + Optic join | 3,977ms + 160ms URI collection | Yes |
 | **B: `op.fromSearch(scopedCtsQuery)` + Optic join** | **125ms** | **Yes** |
 
-**32× speedup.** Identical facet values, counts, and ordering. The URI collection step alone (160ms) exceeds the entire Approach B duration. MarkLogic pushes the CTS query down into the Optic plan optimizer, eliminating both the JS-heap round-trip and the cost of processing a 55K-element `documentQuery` AST node.
+**32× speedup.** Identical facet values, counts, and ordering.
 
 #### Semantic facets (`responsibleCollections`, 2.5M matches)
 
@@ -1844,192 +1851,83 @@ Benchmarked on MarkLogic 12.0.1 against the content database. Scripts in `scratc
 | A: URI list + Optic triple chain | 213,479ms | Yes | 5.5s URI collection + 208s Optic joins |
 | B: `fromSearch(scopedCtsQuery)` + Optic triple chain | 340,537ms | Yes | Optimizer does *worse* with CTS query than URI list |
 | D: Optic with denormalized `itemMemberOfId` field (unfiltered) | 753ms | No | Returns 985 values (all `la:member_of` targets, not just collections) |
-| E: Optic denormalized field + collection-set join filter | 1,574ms | Yes | D + projection barrier + `fromSearch`/`fromLexicons` collection filter |
+| E: Optic denormalized field + collection-set join filter | 1,574ms | Yes | D + projection barrier + collection filter |
 | **C: CTS enumerate + estimate** | **326ms** | **Yes** | 66 candidates × `cts.estimate`, no Optic |
 
 **Key findings:**
 
-1. **Non-semantic facets: Opt 21 `docsPlan` swap works.** Replacing `cts.documentQuery(uriList)` with `op.fromSearch(scopedCtsQuery)` yields a 32× speedup with identical results. The Optic `joinInner` + `groupBy` + `orderBy` chain is fast (125ms for 55K matches) when the plan is simple (one `fromSearch` + one `fromLexicons`).
+1. **Non-semantic facets:** Replacing `cts.documentQuery(uriList)` with `op.fromSearch(scopedCtsQuery)` yields a 32× speedup with identical results. The single `fromSearch` + `fromLexicons` join plan is fast (125ms for 55K matches).
 
-2. **Semantic facets: the Optic triple chain is the bottleneck, not `docsPlan`.** The `fromSearch → fromLexicons(iri) → fromTriples(la:member_of) → fromSearch(Set) → fromLexicons(setIri)` chain creates a massive plan that the optimizer struggles with at 2.5M scale. Approach B (CTS query `docsPlan`) is actually *slower* than A (URI list `docsPlan`) — 340s vs 213s — because the optimizer handles a compact `documentQuery` node more efficiently than an open-ended `fromSearch` CTS query when the downstream plan is already complex.
+2. **Semantic facets:** The Optic triple chain (`fromSearch → fromLexicons(iri) → fromTriples → fromSearch(Set) → fromLexicons(setIri)`) is the bottleneck, not `docsPlan`. At 2.5M scale it takes 210-340s regardless of how the document set is defined. CTS query `docsPlan` (B) is actually *slower* than URI list `docsPlan` (A) — the optimizer handles a compact `documentQuery` node more efficiently when the downstream plan is complex.
 
-3. **Denormalized field indexes exist but don't fully solve it.** `itemMemberOfId` pre-indexes the `la:member_of` triple relationship, eliminating `fromTriples`. But (D) returns all `memberOfId` values without filtering to collection-classified sets, and adding the collection filter join (E) doubles the cost. At 1,574ms, E is 135× faster than A/B but still 4.8× slower than CTS.
+3. **Denormalized field indexes** (`itemMemberOfId`) help (753ms unfiltered, 1,574ms filtered) but are still 4.8× slower than CTS because Optic routes through the plan optimizer and row pipeline.
 
-4. **CTS enumerate-and-estimate is structurally superior for semantic facets.** The CTS production approach (C) inverts the problem: instead of joining 2.5M item documents to triple chains, it enumerates ~66 candidate collection-classified Set documents (search-independent, sub-millisecond each), then calls `cts.estimate(cts.andQuery([fieldValueQuery('itemMemberOfId', uri), scopedCtsQuery]))` per candidate. Each `cts.estimate` is a pure index intersection — no Optic optimizer, no plan AST, no triple traversal. 326ms total.
+4. **CTS enumerate-and-estimate** inverts the problem: enumerate ~66 candidate Set documents (search-independent), then `cts.estimate` per candidate using field-index intersection. No Optic plan, no triple traversal. 326ms total — 1,044× faster than the Optic triple chain.
 
-5. **Why CTS semantic wins:** The denormalized field index (`itemMemberOfId`) encodes the triple relationship at ingest time. The CTS approach leverages this via `cts.estimate` (index intersection), while Optic approaches D/E still process it through the plan optimizer + row pipeline. CTS also naturally filters candidates via `potentialFacetValuesCtsQuery` — only collection-classified Set documents are enumerated, so `cts.estimate` is never called for irrelevant values.
+5. **`responsibleUnits`** has a 3-hop chain with no single denormalized field equivalent. Its CTS config uses `cts.triples` + `cts.documentQuery` nesting to pre-compute candidates — manageable because the enumeration runs once (search-independent) and per-value `cts.estimate` calls use the same field-index intersection pattern.
 
-6. **The `responsibleUnits` semantic facet has a 3-hop SPARQL chain with no single denormalized field equivalent.** Its CTS config (`semanticFacetsConfigCTS.mjs`) uses elaborate `cts.triples` + `cts.documentQuery` nesting to pre-compute candidates. This complexity is manageable in the CTS config because it runs once (search-independent), and the per-value `cts.estimate` calls use the same field-index intersection pattern.
+#### Performance test results
 
-### Why a three-way fork is required
+TODO: Add 10k performance test results comparing pre-Opt-21 baselines (IDs 22, 26, 30) against Opt 21 enabled.
 
-Optimal facet performance requires three distinct execution paths, gated by CTS query availability and facet type:
+### Implementation
 
-```
-if (scopedCtsQuery) {
-  if (isSemanticFacet) {
-    // Path 1: CTS enumerate + estimate (Approach C)
-    // - Enumerate candidates via cts.search(potentialFacetValuesCtsQuery)
-    // - Count per candidate via cts.estimate(getValuesCountCtsQuery(scopedCtsQuery, uri))
-    // - No Optic plan, no triple joins, no fromSearch
-  } else {
-    // Path 2: Optic with CTS query docsPlan (Approach B)
-    // - docsPlan = op.fromSearch(scopedCtsQuery)
-    // - Standard fromLexicons join + groupBy + orderBy
-    // - Same code shape as today, just swap docsPlan source
-  }
-} else {
-  // Path 3: Current materialization + URI list (unchanged)
-  // - Full row materialization, extract URIs
-  // - docsPlan = op.fromSearch(cts.documentQuery(uriList))
-  // - Used for non-foldable queries (hopInverse, transitive hopWithField, annTopK)
-}
+The implementation spans three layers: execution strategy in `performSearch`, facet dispatch in `calculateFacets`, and per-facet CTS configuration in `semanticFacetsConfig.mjs`.
+
+#### `performSearch` execution paths ([engine.mjs](/src/main/ml-modules/root/lib/search/engine.mjs))
+
+Three branches in `performSearch` determine how rows are produced, then a single `calculateFacets` call handles all facet computation:
+
+1. **CTS-eligible (`ctsExecutionEligible`):** Search results are requested, the accumulator is join-free, and `scopedCtsQuery` is non-null. Page results use `cts.estimate` (total) + `offset/limit` (page slice) via Opt 18/20. `rows` stays `null` — no full materialization.
+
+2. **Facet-only with CTS (`!includeSearchResults && scopedCtsQuery`):** Facets were requested without search results and the query is CTS-foldable. `rows` stays `null`. No plan execution at all — `calculateFacets` works directly from `scopedCtsQuery`.
+
+3. **Full materialization (else):** The query has joins (hops, annTopK) or other conditions that prevent CTS execution. All matching rows are materialized. Search results are paginated from the array if requested. `rows` is passed to `calculateFacets` for URI extraction.
+
+After the branch, one call:
+
+```javascript
+facetResponses = calculateFacets(rows, facetRequests, scopedCtsQuery);
 ```
 
-**Why not a uniform Optic path?** The Optic approach works well for non-semantic facets (Path 2: 125ms) because the plan is simple: `fromSearch → joinInner(fromLexicons) → groupBy`. For semantic facets, the plan grows to 4-5 joins with `fromTriples`/`fromSPARQL`, and the optimizer cannot efficiently process the resulting plan at 2.5M scale (210-340s). Even replacing the triple chain with a denormalized field index (Approach E: 1,574ms) is 4.8× slower than CTS (326ms) because Optic still routes through the plan optimizer and row pipeline.
+`isCtsExecutionEligible` no longer checks for facet requests — Opt 21 made facets compatible with the CTS execution path. This means Opt 18/20 now fire even when facets are co-requested with search results, avoiding full materialization entirely for join-free queries.
 
-**Why not a uniform CTS path?** CTS `cts.fieldValues(indexRef, null, opts, scopedCtsQuery)` could replace Path 2 for non-semantic facets — it's what CTS production uses. But Path 2 (Optic) is already fast (125ms) and requires only swapping the `docsPlan` source, which is a minimal code change that preserves the existing `calculateFacets` structure. A full CTS migration for non-semantic facets would mean duplicating pagination, sort-order, and date-facet handling already implemented in the Optic path. The marginal performance gain (if any) doesn't justify the code duplication. If a future benchmark shows CTS `fieldValues` is materially faster, it can be revisited.
+#### `calculateFacets` dispatch ([calculateFacets.mjs](/src/main/ml-modules/root/lib/search/calculateFacets.mjs))
 
-**Why CTS is required for semantic facets specifically:**
+Three paths per facet, gated by `scopedCtsQuery` and facet type:
 
-| Factor | Optic semantic (A/B/E) | CTS semantic (C) |
+- **Path 1 — CTS semantic** (`isSemanticFacet && scopedCtsQuery`): Enumerate candidates via `cts.search(potentialFacetValuesCtsQuery)`, count each via `cts.estimate(getValuesCountCtsQuery(scopedCtsQuery, uri))`, filter count > 0, sort by count desc. No Optic plan. Capped at `SEMANTIC_VALUE_LIMIT` (100) — both current semantic facets (`responsibleCollections`: ~66 values, `responsibleUnits`: fewer) are well within this limit.
+
+- **Path 2 — Optic with CTS query** (`!isSemanticFacet && scopedCtsQuery`): `op.fromSearch(scopedCtsQuery)` replaces the old `cts.documentQuery(uriList)`. The downstream Optic chain (`joinInner(fromLexicons) → groupBy → orderBy`) is unchanged.
+
+- **Path 3 — Optic with URI list** (no `scopedCtsQuery`): Fallback for non-foldable queries. `rows.map(r => r.id)` extracts URIs, `op.fromSearch(cts.documentQuery(uriList))` builds the document set. This is the pre-Opt-21 behavior, used when the query involves `hopInverse`, transitive `hopWithField`, or `annTopK`.
+
+**Why not a uniform Optic path?** Optic works well for non-semantic facets (Path 2: 125ms) because the plan is simple. For semantic facets, the plan grows to 4-5 joins with `fromTriples`/`fromSPARQL`, and the optimizer cannot efficiently process it at 2.5M scale (210-340s). Even denormalized field indexes (1,574ms) are 4.8× slower than CTS.
+
+**Why not a uniform CTS path?** CTS `cts.fieldValues` could replace Path 2, but Optic is already fast (125ms) and preserves the existing pagination, sort-order, and date-facet handling. The marginal gain doesn't justify the code duplication.
+
+#### Semantic facet configuration ([semanticFacetsConfig.mjs](/src/main/ml-modules/root/config/semanticFacetsConfig.mjs))
+
+Each semantic facet requires configuration for both CTS (Path 1) and Optic (Path 3):
+
+| Property | Path | Purpose |
 |---|---|---|
-| Triple traversal | Runtime via `fromTriples`/`fromSPARQL` | Pre-indexed field (`itemMemberOfId`) via `cts.estimate` |
-| Plan complexity | 4-5 joins, complex AST | No Optic plan — `cts.search` + N × `cts.estimate` |
-| Candidate filtering | Join-based (adds cost) | Structural — `potentialFacetValuesCtsQuery` enumerates only valid candidates |
-| Scale sensitivity | O(matches × join chain) — 340s at 2.5M | O(candidates × cts.estimate) — 326ms for 66 candidates at 2.5M |
-| Config requirements | `plan`, `sourceJoinColName`, `constraintJoinColName`, `facetValueColName` | `potentialFacetValuesCtsQuery`, `getValuesCountCtsQuery` |
+| `potentialFacetValuesCtsQuery` | 1 | CTS query to enumerate candidate facet values (search-independent) |
+| `getValuesCountCtsQuery(scopedCtsQuery, uri)` | 1 | Returns a CTS query that counts items matching `scopedCtsQuery` AND the candidate value |
+| `plan` | 3 | Optic plan for the triple/SPARQL join chain |
+| `sourceJoinColName` | 2, 3 | Column from `docsPlan` to join on |
+| `constraintJoinColName` | 2, 3 | Column from `plan` to join on |
+| `facetValueColName` | 2, 3 | Column containing the facet value URI |
 
-**Engineering escalation items:**
+The CTS properties were ported from the CTS-based search implementation. The Optic properties are retained for the Path 3 fallback.
 
-1. **`op.fromSearch(ctsQuery)` + `fromTriples` performance at scale.** The optimizer produces a worse plan with `fromSearch(ctsQuery)` (340s) than with `fromSearch(documentQuery(uriList))` (213s) for the same 2.5M-match semantic facet. This suggests the optimizer may be choosing different join orders or strategies when the document set is defined by a CTS query vs. an explicit URI list. This is unexpected — the CTS query should allow the optimizer more freedom, not less.
+#### Source files
 
-2. **CTS query parameterization within Optic.** The non-semantic `fromSearch(scopedCtsQuery)` result (125ms) demonstrates that the optimizer handles CTS queries well in simple plans. But plan caching cannot help because each distinct `scopedCtsQuery` produces a distinct plan AST. If MarkLogic supported parameterized CTS queries within `fromSearch` (where the query structure is fixed but literal values are parameters), plan cache reuse would improve cold-start performance.
-
-3. **Semantic facet Optic plan cost.** The `responsibleCollections` plan involves `fromSearch → fromLexicons(iri) → fromTriples → fromSearch(Set) → fromLexicons(setIri)` — 5 plan nodes chained via `joinInner`. At 2.5M matches, this takes 210-340s. Is there an optimizer hint or plan shape that could reduce this? The denormalized field approach (E: 1,574ms) helps 135× but is still 4.8× slower than bypassing Optic entirely.
-
-### Approach
-
-The implementation now has two dimensions: the `docsPlan` swap for non-semantic facets, and the CTS path for semantic facets.
-
-#### Non-semantic facets (Path 2): `docsPlan` swap
-
-When `scopedCtsQuery` is available, replace:
-
-```javascript
-const docsPlan = op.fromSearch(cts.documentQuery(uriList));
-```
-
-With:
-
-```javascript
-const docsPlan = op.fromSearch(scopedCtsQuery);
-```
-
-The rest of the non-semantic facet code (`joinInner(fromLexicons)` → `groupBy` → `orderBy`) is unchanged.
-
-#### Semantic facets (Path 1): CTS enumerate-and-estimate
-
-When `scopedCtsQuery` is available, bypass the Optic join chain entirely:
-
-```javascript
-// 1. Enumerate candidates (search-independent)
-const candidates = fn.subsequence(
-  cts.search(semanticConfig.potentialFacetValuesCtsQuery, ['unfiltered', 'unfaceted', 'score-zero']),
-  1, SEMANTIC_VALUE_LIMIT + 1
-).toArray();
-
-// 2. Count per candidate via index intersection
-const facetValues = candidates
-  .map(doc => ({
-    value: doc.baseURI,
-    count: cts.estimate(semanticConfig.getValuesCountCtsQuery(scopedCtsQuery, doc.baseURI))
-  }))
-  .filter(fv => fv.count > 0)
-  .sort((a, b) => b.count - a.count);
-```
-
-This requires adding `potentialFacetValuesCtsQuery` and `getValuesCountCtsQuery` to the Optic engine's `semanticFacetsConfig.mjs`. These properties already exist in the CTS production's `semanticFacetsConfigCTS.mjs` and can be ported directly.
-
-### Eligibility
-
-This optimization applies when `buildScopedCtsQuery` returns non-null (the accumulator is join-free and can be expressed as a pure CTS query). This is the same `isAccumulatorJoinFree` check used by Opt 18 and Opt 20.
-
-Note the distinction from `isCtsExecutionEligible`: that function also checks `!facetRequests?.length`, which would always be false for facet requests. The CTS query eligibility is determined by the accumulator shape, not the request type. The relevant check is:
-
-```javascript
-const scopedCtsQuery = buildScopedCtsQuery(acc, assemblyContext, analysis.scope);
-const hasCtsQuery = scopedCtsQuery != null;
-```
-
-When `hasCtsQuery` is true, the CTS query can be used for both facet computation and (if page results are also requested) Opt 18/20.
-
-### Implementation plan
-
-#### 1. Add CTS config properties to `semanticFacetsConfig.mjs`
-
-Port `potentialFacetValuesCtsQuery` and `getValuesCountCtsQuery` from `semanticFacetsConfigCTS.mjs` into the Optic engine's config. The existing Optic-specific properties (`plan`, `sourceJoinColName`, etc.) remain for the non-CTS-eligible path (Path 3).
-
-#### 2. Modify `calculateFacets` signature
-
-```javascript
-function calculateFacets(rows, facetRequests, scopedCtsQuery = null)
-```
-
-#### 3. Three-path dispatch inside `calculateFacets`
-
-```javascript
-requests.forEach((request) => {
-  const facetName = request?.name;
-
-  if (isSemanticFacet(facetName) && scopedCtsQuery) {
-    // Path 1: CTS enumerate + estimate
-    facets[facetName] = calculateSemanticFacetViaCts(facetName, scopedCtsQuery, start, end);
-  } else {
-    // Path 2 or 3: Optic join (either CTS query or URI-list docsPlan)
-    // ... existing Optic code, with docsPlan = scopedCtsQuery
-    //     ? op.fromSearch(scopedCtsQuery) : op.fromSearch(cts.documentQuery(uriList))
-  }
-});
-```
-
-#### 4. Modify `performSearch` to pass `scopedCtsQuery`
-
-```javascript
-facetResponses = calculateFacets(rows, facetRequests, hasCtsQuery ? scopedCtsQuery : null);
-```
-
-When `hasCtsQuery && !includeSearchResults`, `rows` can be `null` — the CTS paths don't access it.
-
-#### 5. Verify correctness
-
-- **Non-semantic parity:** Validated. Approach B produces identical values, counts, and ordering as Approach A for `itemTypeId` facet over 55K matches.
-- **Semantic parity:** Compare Approach C output against Approach A output for `responsibleCollections` and `responsibleUnits`. The CTS approach may return slightly different counts than Optic due to `cts.estimate` vs. exact `groupBy` — `cts.estimate` is an approximation. Document any discrepancy.
-- **Empty results:** When the CTS query matches zero documents, each `cts.estimate` returns 0, all candidates are filtered out, and `totalItems` is 0 — matching `buildEmptyFacetResponses`.
-
-### What this does NOT address
-
-- **Non-foldable queries.** When the accumulator has joins (`hopInverse`, transitive `hopWithField`, `annTopK`), there is no CTS query to pass. The current materialization + URI-list path remains (Path 3). [Opt 19](#optimization-19-datatype-split-estimate-for-non-cts-foldable-searches) is a separate idea for those cases.
-- **Consolidation (page + facets in one call).** This optimization works when page + facets are consolidated: the page uses Opt 18/20 while facets use Opt 21. No materialization needed for either. However, this consolidated call path is not currently exercised — `performSearch` is called for page OR facet, never both.
-- **Semantic facets with >100 values.** The CTS enumerate-and-estimate approach is capped at `SEMANTIC_VALUE_LIMIT` (100). If a semantic facet exceeds this, the CTS approach underreports. The current two semantic facets (`responsibleCollections`: 66 values, `responsibleUnits`: fewer) are well within the limit. If a high-cardinality semantic facet is added, this limit would need to be revisited — but the Optic approach is not viable at that scale either (210-340s for 2.5M matches).
-
-### Relationship to other optimizations
-
-- **Opt 18 (cts.estimate with offset/limit):** Shares the same `scopedCtsQuery` computation. Opt 18 uses it for `cts.estimate` (total count); Opt 21 uses it for both `op.fromSearch` (non-semantic facets) and `cts.estimate` (semantic facet per-value counts). The two are independent — neither is a prerequisite.
-- **Opt 20 (Eliminate fromLexicons):** Not a prerequisite. Opt 20 addresses page results; Opt 21 addresses facets. They are complementary and can be implemented in either order. When both are implemented and page + facets are consolidated into one call, the full materialization path is only needed for non-foldable queries.
-- **Opt 19 (DataType-split estimate):** Opt 19 targets the non-foldable case (queries with joins). Opt 21 targets the foldable case (join-free). They address different subsets of the query population.
-
-### Estimated impact
-
-For the `item.memberOf` reference query (2.5M matches):
-
-| Step | Current cost | With Opt 21 |
-|---|---|---|
-| Materialize all rows | 15s+ (2.5M rows) | **Eliminated** |
-| Extract URIs | ~500ms | **Eliminated** |
-| Build `cts.documentQuery(2.5M URIs)` | Massive plan AST | **Eliminated** |
-| Non-semantic facet (per facet) | ~200ms (join + groupBy) | ~125ms (`fromSearch(ctsQuery)`) |
-| Semantic facet (per facet) | 210-340s (Optic triple chain) | **326ms** (CTS enumerate + estimate) |
+| File | Change |
+|---|---|
+| [calculateFacets.mjs](/src/main/ml-modules/root/lib/search/calculateFacets.mjs) | New module — three-way dispatch, extracted from `engine.mjs` |
+| [engine.mjs](/src/main/ml-modules/root/lib/search/engine.mjs) | Removed ~150-line facets region. Single `calculateFacets` call after execution branch. Removed facet guard from `isCtsExecutionEligible`. |
+| [semanticFacetsConfig.mjs](/src/main/ml-modules/root/config/semanticFacetsConfig.mjs) | Added `potentialFacetValuesCtsQuery` and `getValuesCountCtsQuery` to `responsibleCollections` and `responsibleUnits` |
 
 ## Optimization 22: annTopK post-filter for HNSW index usage
 

--- a/docs/lux-optic-primer.md
+++ b/docs/lux-optic-primer.md
@@ -1807,7 +1807,7 @@ The mean result is the headline: Optic went from 2.3× slower than CTS to 3.2× 
 
 ## Optimization 21: Eliminate URI-list materialization for facets
 
-**Status:** Idea — not yet prototyped.
+**Status:** Validated — implementation pending.
 
 ### Problem
 
@@ -1824,11 +1824,132 @@ For large result sets, this has three costs:
 2. **URI-list AST bloat.** `cts.documentQuery(uriList)` with 219K URI strings produces a massive plan AST node. This is the same class of optimizer-cost problem as the keyword pattern's 49K IRIs in `cts.tripleRangeQuery`.
 3. **Redundant work.** The Optic plan already determined which documents match. Materializing them into JS, extracting URIs, and feeding them back into a new Optic plan via `documentQuery` is a round-trip through the V8 heap that MarkLogic's indexes could skip entirely.
 
+### Validation results
+
+Benchmarked on MarkLogic 12.0.1 against the content database. Scripts in `scratch/performance/opt21-*.js`.
+
+#### Non-semantic facets (`itemTypeId`, 55K matches, `cts.fieldWordQuery('itemAnyText', 'painting')`)
+
+| Approach | Duration | Match? |
+|---|---|---|
+| A: `op.fromSearch(cts.documentQuery(uriList))` + Optic join | 3,977ms + 160ms URI collection | Yes |
+| **B: `op.fromSearch(scopedCtsQuery)` + Optic join** | **125ms** | **Yes** |
+
+**32× speedup.** Identical facet values, counts, and ordering. The URI collection step alone (160ms) exceeds the entire Approach B duration. MarkLogic pushes the CTS query down into the Optic plan optimizer, eliminating both the JS-heap round-trip and the cost of processing a 55K-element `documentQuery` AST node.
+
+#### Semantic facets (`responsibleCollections`, 2.5M matches)
+
+| Approach | Duration | Correct? | Notes |
+|---|---|---|---|
+| A: URI list + Optic triple chain | 213,479ms | Yes | 5.5s URI collection + 208s Optic joins |
+| B: `fromSearch(scopedCtsQuery)` + Optic triple chain | 340,537ms | Yes | Optimizer does *worse* with CTS query than URI list |
+| D: Optic with denormalized `itemMemberOfId` field (unfiltered) | 753ms | No | Returns 985 values (all `la:member_of` targets, not just collections) |
+| E: Optic denormalized field + collection-set join filter | 1,574ms | Yes | D + projection barrier + `fromSearch`/`fromLexicons` collection filter |
+| **C: CTS enumerate + estimate** | **326ms** | **Yes** | 66 candidates × `cts.estimate`, no Optic |
+
+**Key findings:**
+
+1. **Non-semantic facets: Opt 21 `docsPlan` swap works.** Replacing `cts.documentQuery(uriList)` with `op.fromSearch(scopedCtsQuery)` yields a 32× speedup with identical results. The Optic `joinInner` + `groupBy` + `orderBy` chain is fast (125ms for 55K matches) when the plan is simple (one `fromSearch` + one `fromLexicons`).
+
+2. **Semantic facets: the Optic triple chain is the bottleneck, not `docsPlan`.** The `fromSearch → fromLexicons(iri) → fromTriples(la:member_of) → fromSearch(Set) → fromLexicons(setIri)` chain creates a massive plan that the optimizer struggles with at 2.5M scale. Approach B (CTS query `docsPlan`) is actually *slower* than A (URI list `docsPlan`) — 340s vs 213s — because the optimizer handles a compact `documentQuery` node more efficiently than an open-ended `fromSearch` CTS query when the downstream plan is already complex.
+
+3. **Denormalized field indexes exist but don't fully solve it.** `itemMemberOfId` pre-indexes the `la:member_of` triple relationship, eliminating `fromTriples`. But (D) returns all `memberOfId` values without filtering to collection-classified sets, and adding the collection filter join (E) doubles the cost. At 1,574ms, E is 135× faster than A/B but still 4.8× slower than CTS.
+
+4. **CTS enumerate-and-estimate is structurally superior for semantic facets.** The CTS production approach (C) inverts the problem: instead of joining 2.5M item documents to triple chains, it enumerates ~66 candidate collection-classified Set documents (search-independent, sub-millisecond each), then calls `cts.estimate(cts.andQuery([fieldValueQuery('itemMemberOfId', uri), scopedCtsQuery]))` per candidate. Each `cts.estimate` is a pure index intersection — no Optic optimizer, no plan AST, no triple traversal. 326ms total.
+
+5. **Why CTS semantic wins:** The denormalized field index (`itemMemberOfId`) encodes the triple relationship at ingest time. The CTS approach leverages this via `cts.estimate` (index intersection), while Optic approaches D/E still process it through the plan optimizer + row pipeline. CTS also naturally filters candidates via `potentialFacetValuesCtsQuery` — only collection-classified Set documents are enumerated, so `cts.estimate` is never called for irrelevant values.
+
+6. **The `responsibleUnits` semantic facet has a 3-hop SPARQL chain with no single denormalized field equivalent.** Its CTS config (`semanticFacetsConfigCTS.mjs`) uses elaborate `cts.triples` + `cts.documentQuery` nesting to pre-compute candidates. This complexity is manageable in the CTS config because it runs once (search-independent), and the per-value `cts.estimate` calls use the same field-index intersection pattern.
+
+### Why a three-way fork is required
+
+Optimal facet performance requires three distinct execution paths, gated by CTS query availability and facet type:
+
+```
+if (scopedCtsQuery) {
+  if (isSemanticFacet) {
+    // Path 1: CTS enumerate + estimate (Approach C)
+    // - Enumerate candidates via cts.search(potentialFacetValuesCtsQuery)
+    // - Count per candidate via cts.estimate(getValuesCountCtsQuery(scopedCtsQuery, uri))
+    // - No Optic plan, no triple joins, no fromSearch
+  } else {
+    // Path 2: Optic with CTS query docsPlan (Approach B)
+    // - docsPlan = op.fromSearch(scopedCtsQuery)
+    // - Standard fromLexicons join + groupBy + orderBy
+    // - Same code shape as today, just swap docsPlan source
+  }
+} else {
+  // Path 3: Current materialization + URI list (unchanged)
+  // - Full row materialization, extract URIs
+  // - docsPlan = op.fromSearch(cts.documentQuery(uriList))
+  // - Used for non-foldable queries (hopInverse, transitive hopWithField, annTopK)
+}
+```
+
+**Why not a uniform Optic path?** The Optic approach works well for non-semantic facets (Path 2: 125ms) because the plan is simple: `fromSearch → joinInner(fromLexicons) → groupBy`. For semantic facets, the plan grows to 4-5 joins with `fromTriples`/`fromSPARQL`, and the optimizer cannot efficiently process the resulting plan at 2.5M scale (210-340s). Even replacing the triple chain with a denormalized field index (Approach E: 1,574ms) is 4.8× slower than CTS (326ms) because Optic still routes through the plan optimizer and row pipeline.
+
+**Why not a uniform CTS path?** CTS `cts.fieldValues(indexRef, null, opts, scopedCtsQuery)` could replace Path 2 for non-semantic facets — it's what CTS production uses. But Path 2 (Optic) is already fast (125ms) and requires only swapping the `docsPlan` source, which is a minimal code change that preserves the existing `calculateFacets` structure. A full CTS migration for non-semantic facets would mean duplicating pagination, sort-order, and date-facet handling already implemented in the Optic path. The marginal performance gain (if any) doesn't justify the code duplication. If a future benchmark shows CTS `fieldValues` is materially faster, it can be revisited.
+
+**Why CTS is required for semantic facets specifically:**
+
+| Factor | Optic semantic (A/B/E) | CTS semantic (C) |
+|---|---|---|
+| Triple traversal | Runtime via `fromTriples`/`fromSPARQL` | Pre-indexed field (`itemMemberOfId`) via `cts.estimate` |
+| Plan complexity | 4-5 joins, complex AST | No Optic plan — `cts.search` + N × `cts.estimate` |
+| Candidate filtering | Join-based (adds cost) | Structural — `potentialFacetValuesCtsQuery` enumerates only valid candidates |
+| Scale sensitivity | O(matches × join chain) — 340s at 2.5M | O(candidates × cts.estimate) — 326ms for 66 candidates at 2.5M |
+| Config requirements | `plan`, `sourceJoinColName`, `constraintJoinColName`, `facetValueColName` | `potentialFacetValuesCtsQuery`, `getValuesCountCtsQuery` |
+
+**Engineering escalation items:**
+
+1. **`op.fromSearch(ctsQuery)` + `fromTriples` performance at scale.** The optimizer produces a worse plan with `fromSearch(ctsQuery)` (340s) than with `fromSearch(documentQuery(uriList))` (213s) for the same 2.5M-match semantic facet. This suggests the optimizer may be choosing different join orders or strategies when the document set is defined by a CTS query vs. an explicit URI list. This is unexpected — the CTS query should allow the optimizer more freedom, not less.
+
+2. **CTS query parameterization within Optic.** The non-semantic `fromSearch(scopedCtsQuery)` result (125ms) demonstrates that the optimizer handles CTS queries well in simple plans. But plan caching cannot help because each distinct `scopedCtsQuery` produces a distinct plan AST. If MarkLogic supported parameterized CTS queries within `fromSearch` (where the query structure is fixed but literal values are parameters), plan cache reuse would improve cold-start performance.
+
+3. **Semantic facet Optic plan cost.** The `responsibleCollections` plan involves `fromSearch → fromLexicons(iri) → fromTriples → fromSearch(Set) → fromLexicons(setIri)` — 5 plan nodes chained via `joinInner`. At 2.5M matches, this takes 210-340s. Is there an optimizer hint or plan shape that could reduce this? The denormalized field approach (E: 1,574ms) helps 135× but is still 4.8× slower than bypassing Optic entirely.
+
 ### Approach
 
-When the search criteria produce a CTS query (join-free accumulator), pass the CTS query directly to `calculateFacets` instead of materializing rows. `calculateFacets` uses it as `docsPlan = op.fromSearch(ctsQuery)` — a compact CTS query reference instead of a 219K-URI literal list.
+The implementation now has two dimensions: the `docsPlan` swap for non-semantic facets, and the CTS path for semantic facets.
 
-For non-foldable searches (accumulator has joins), the current materialization path remains unchanged.
+#### Non-semantic facets (Path 2): `docsPlan` swap
+
+When `scopedCtsQuery` is available, replace:
+
+```javascript
+const docsPlan = op.fromSearch(cts.documentQuery(uriList));
+```
+
+With:
+
+```javascript
+const docsPlan = op.fromSearch(scopedCtsQuery);
+```
+
+The rest of the non-semantic facet code (`joinInner(fromLexicons)` → `groupBy` → `orderBy`) is unchanged.
+
+#### Semantic facets (Path 1): CTS enumerate-and-estimate
+
+When `scopedCtsQuery` is available, bypass the Optic join chain entirely:
+
+```javascript
+// 1. Enumerate candidates (search-independent)
+const candidates = fn.subsequence(
+  cts.search(semanticConfig.potentialFacetValuesCtsQuery, ['unfiltered', 'unfaceted', 'score-zero']),
+  1, SEMANTIC_VALUE_LIMIT + 1
+).toArray();
+
+// 2. Count per candidate via index intersection
+const facetValues = candidates
+  .map(doc => ({
+    value: doc.baseURI,
+    count: cts.estimate(semanticConfig.getValuesCountCtsQuery(scopedCtsQuery, doc.baseURI))
+  }))
+  .filter(fv => fv.count > 0)
+  .sort((a, b) => b.count - a.count);
+```
+
+This requires adding `potentialFacetValuesCtsQuery` and `getValuesCountCtsQuery` to the Optic engine's `semanticFacetsConfig.mjs`. These properties already exist in the CTS production's `semanticFacetsConfigCTS.mjs` and can be ported directly.
 
 ### Eligibility
 
@@ -1841,150 +1962,74 @@ const scopedCtsQuery = buildScopedCtsQuery(acc, assemblyContext, analysis.scope)
 const hasCtsQuery = scopedCtsQuery != null;
 ```
 
-When `hasCtsQuery` is true, the CTS query can be used for both facet document-set definition and (if page results are also requested) Opt 18/20.
+When `hasCtsQuery` is true, the CTS query can be used for both facet computation and (if page results are also requested) Opt 18/20.
 
 ### Implementation plan
 
-The change spans two functions in `engine.mjs`: `performSearch` (the call site) and `calculateFacets` (the consumer).
+#### 1. Add CTS config properties to `semanticFacetsConfig.mjs`
 
-#### 1. Modify `calculateFacets` to accept an optional CTS query
+Port `potentialFacetValuesCtsQuery` and `getValuesCountCtsQuery` from `semanticFacetsConfigCTS.mjs` into the Optic engine's config. The existing Optic-specific properties (`plan`, `sourceJoinColName`, etc.) remain for the non-CTS-eligible path (Path 3).
 
-Change the signature from:
+#### 2. Modify `calculateFacets` signature
 
 ```javascript
-function calculateFacets(rows, facetRequests)
+function calculateFacets(rows, facetRequests, scopedCtsQuery = null)
 ```
 
-To:
+#### 3. Three-path dispatch inside `calculateFacets`
 
 ```javascript
-function calculateFacets(rows, facetRequests, ctsQuery = null)
-```
+requests.forEach((request) => {
+  const facetName = request?.name;
 
-Replace the `docsPlan` construction:
-
-```javascript
-// Current:
-const uriList = rows.map((row) => row.id);
-if (!utils.isNonEmptyArray(uriList)) {
-  return buildEmptyFacetResponses(requests);
-}
-// ...
-const docsPlan = op.fromSearch(cts.documentQuery(uriList));
-
-// New:
-let docsPlan;
-if (ctsQuery) {
-  // Opt 21: use CTS query directly -- no URI materialization, no AST bloat.
-  docsPlan = op.fromSearch(ctsQuery);
-} else {
-  const uriList = rows.map((row) => row.id);
-  if (!utils.isNonEmptyArray(uriList)) {
-    return buildEmptyFacetResponses(requests);
+  if (isSemanticFacet(facetName) && scopedCtsQuery) {
+    // Path 1: CTS enumerate + estimate
+    facets[facetName] = calculateSemanticFacetViaCts(facetName, scopedCtsQuery, start, end);
+  } else {
+    // Path 2 or 3: Optic join (either CTS query or URI-list docsPlan)
+    // ... existing Optic code, with docsPlan = scopedCtsQuery
+    //     ? op.fromSearch(scopedCtsQuery) : op.fromSearch(cts.documentQuery(uriList))
   }
-  docsPlan = op.fromSearch(cts.documentQuery(uriList));
-}
+});
 ```
 
-The rest of `calculateFacets` is unchanged. Every facet's `facetSourcePlan` starts from `docsPlan` and joins to its constraint plan — the `docsPlan` construction is the only difference.
-
-**Empty-result guard:** When `ctsQuery` is provided, the `isNonEmptyArray(uriList)` guard is bypassed. If the CTS query matches zero documents, `op.fromSearch(ctsQuery)` produces zero rows, and each facet's `joinInner` produces zero rows — the correct behavior. But `facets[facetName].totalItems` will be 0, matching the empty-facet response. Verify this behaves identically to the `buildEmptyFacetResponses` path.
-
-#### 2. Modify `performSearch` to pass `scopedCtsQuery` to `calculateFacets`
-
-The current `performSearch` structure (simplified):
+#### 4. Modify `performSearch` to pass `scopedCtsQuery`
 
 ```javascript
-if (canEstimate) {
-  // Opt 18 path: page results only, no facets
-  total = cts.estimate(scopedCtsQuery);
-  searchResults = useThisPlan.offset(offset).limit(pageLength).result().toArray();
-} else {
-  // Full materialization path
-  const rows = useThisPlan.result().toArray();
-  if (includeSearchResults) {
-    total = rows.length;
-    // ... paginate ...
-  }
-  facetResponses = calculateFacets(rows, facetRequests);
-}
+facetResponses = calculateFacets(rows, facetRequests, hasCtsQuery ? scopedCtsQuery : null);
 ```
 
-The key insight: `isCtsExecutionEligible` returns false when facets are requested (it checks `!facetRequests?.length`). But `scopedCtsQuery` may still be non-null — the accumulator is join-free, the CTS query exists, it's just that `isCtsExecutionEligible` also gates on the absence of facets.
+When `hasCtsQuery && !includeSearchResults`, `rows` can be `null` — the CTS paths don't access it.
 
-Refactored:
+#### 5. Verify correctness
 
-```javascript
-const hasCtsQuery = scopedCtsQuery != null;
-
-if (canEstimate) {
-  // Opt 18/20 path: page results only, no facets
-  total = cts.estimate(scopedCtsQuery);
-  searchResults = useThisPlan.offset(offset).limit(pageLength).result().toArray();
-} else if (hasCtsQuery && !includeSearchResults && facetRequests?.length > 0) {
-  // Opt 21: facet-only request with join-free accumulator.
-  // No need to materialize rows -- pass CTS query directly.
-  facetResponses = calculateFacets(null, facetRequests, scopedCtsQuery);
-} else {
-  // Full materialization path (non-foldable, or page + facets combined)
-  const rows = useThisPlan.result().toArray();
-  if (includeSearchResults) {
-    total = rows.length;
-    // ... paginate ...
-  }
-  // Pass scopedCtsQuery when available to avoid URI-list AST bloat;
-  // fall back to rows when not.
-  facetResponses = calculateFacets(rows, facetRequests, hasCtsQuery ? scopedCtsQuery : null);
-}
-```
-
-**Five cases:**
-
-| Case | `hasCtsQuery` | `includeSearchResults` | `facetRequests` | What happens |
-|---|---|---|---|---|
-| Page only, no facets | true | true | empty | Opt 18/20 path (unchanged) |
-| Facet only, join-free | true | false | non-empty | **Opt 21: no materialization** — CTS query passed directly |
-| Facet only, non-foldable | false | false | non-empty | Full materialization (unchanged) |
-| Page + facets, join-free | true | true | non-empty | Full materialization BUT `calculateFacets` uses CTS query instead of URI list |
-| Page + facets, non-foldable | false | true | non-empty | Full materialization, URI list (unchanged) |
-
-The fourth case (page + facets, join-free) still materializes for the page — but `calculateFacets` benefits from the CTS query path, avoiding the URI-list AST bloat. If Opt 20 is implemented first, this case could avoid materialization entirely: Opt 20 for the page, Opt 21 for the facets.
-
-#### 3. Handle `rows = null` in `calculateFacets`
-
-When called from the Opt 21 facet-only path, `rows` is `null`. The function must not call `rows.map(...)` in that case. The guard from step 1 handles this — when `ctsQuery` is provided, `rows` is never accessed.
-
-#### 4. Verify correctness
-
-- **Facet parity:** For the same query, compare facet results between the CTS-query path and the URI-list path. Values, counts, ordering, and pagination must match exactly.
-- **Scope filtering:** `scopedCtsQuery` includes the scope dataType filter (`cts.fieldValueQuery('anyDataTypeName', scopeTypes)`). This ensures `op.fromSearch(scopedCtsQuery)` constrains to the correct scope — same guarantee as the current `cts.documentQuery(uriList)` where the URIs were already scope-filtered by the Optic plan.
-- **Semantic facets:** Semantic facets join `docsPlan` to triples via the `iri` column. When `docsPlan` is `op.fromSearch(ctsQuery)`, the plan produces `fragmentId` and (optionally) `score` columns. The semantic facet path does `facetSourcePlan.joinInner(fromLexicons({iri: cts.iriReference()}, ...), op.on('fragmentId', 'iriFragId'))` to add the `iri` column. This should work identically with the CTS-query-based `docsPlan` — the join is on `fragmentId`, which `fromSearch` provides. Verify with a semantic facet request.
-- **Empty results:** When the CTS query matches zero documents, verify that each facet returns `{ totalItems: 0, facetValues: [] }` — matching the existing `buildEmptyFacetResponses` behavior.
+- **Non-semantic parity:** Validated. Approach B produces identical values, counts, and ordering as Approach A for `itemTypeId` facet over 55K matches.
+- **Semantic parity:** Compare Approach C output against Approach A output for `responsibleCollections` and `responsibleUnits`. The CTS approach may return slightly different counts than Optic due to `cts.estimate` vs. exact `groupBy` — `cts.estimate` is an approximation. Document any discrepancy.
+- **Empty results:** When the CTS query matches zero documents, each `cts.estimate` returns 0, all candidates are filtered out, and `totalItems` is 0 — matching `buildEmptyFacetResponses`.
 
 ### What this does NOT address
 
-- **Non-foldable queries.** When the accumulator has joins (`hopInverse`, transitive `hopWithField`, `annTopK`), there is no CTS query to pass. The current materialization + URI-list path remains. [Opt 19](#optimization-19-datatype-split-estimate-for-non-cts-foldable-searches) is a separate idea for those cases.
+- **Non-foldable queries.** When the accumulator has joins (`hopInverse`, transitive `hopWithField`, `annTopK`), there is no CTS query to pass. The current materialization + URI-list path remains (Path 3). [Opt 19](#optimization-19-datatype-split-estimate-for-non-cts-foldable-searches) is a separate idea for those cases.
 - **Consolidation (page + facets in one call).** This optimization works when page + facets are consolidated: the page uses Opt 18/20 while facets use Opt 21. No materialization needed for either. However, this consolidated call path is not currently exercised — `performSearch` is called for page OR facet, never both.
+- **Semantic facets with >100 values.** The CTS enumerate-and-estimate approach is capped at `SEMANTIC_VALUE_LIMIT` (100). If a semantic facet exceeds this, the CTS approach underreports. The current two semantic facets (`responsibleCollections`: 66 values, `responsibleUnits`: fewer) are well within the limit. If a high-cardinality semantic facet is added, this limit would need to be revisited — but the Optic approach is not viable at that scale either (210-340s for 2.5M matches).
 
 ### Relationship to other optimizations
 
-- **Opt 18 (cts.estimate with offset/limit):** Shares the same `scopedCtsQuery` computation. Opt 18 uses it for `cts.estimate` (total count); Opt 21 uses it for `op.fromSearch` (facet document set). The two are independent — neither is a prerequisite.
+- **Opt 18 (cts.estimate with offset/limit):** Shares the same `scopedCtsQuery` computation. Opt 18 uses it for `cts.estimate` (total count); Opt 21 uses it for both `op.fromSearch` (non-semantic facets) and `cts.estimate` (semantic facet per-value counts). The two are independent — neither is a prerequisite.
 - **Opt 20 (Eliminate fromLexicons):** Not a prerequisite. Opt 20 addresses page results; Opt 21 addresses facets. They are complementary and can be implemented in either order. When both are implemented and page + facets are consolidated into one call, the full materialization path is only needed for non-foldable queries.
 - **Opt 19 (DataType-split estimate):** Opt 19 targets the non-foldable case (queries with joins). Opt 21 targets the foldable case (join-free). They address different subsets of the query population.
 
 ### Estimated impact
 
-For the `item.memberOf` reference query (219K matches):
+For the `item.memberOf` reference query (2.5M matches):
 
 | Step | Current cost | With Opt 21 |
 |---|---|---|
-| Materialize all rows | 3-4s (219K rows) | **Eliminated** |
-| Extract URIs | ~50ms | **Eliminated** |
-| Build `cts.documentQuery(219K URIs)` | Plan AST bloat | **Eliminated** |
-| `op.fromSearch(ctsQuery)` | N/A | ~0 (compact CTS reference) |
-| Facet join + groupBy + orderBy | ~200ms (per facet) | ~200ms (unchanged) |
-
-The facet join/aggregation cost is unchanged — the optimization eliminates the materialization and AST-bloat overhead that precedes it. For the 2.5M-row case (Sterling Memorial Library), the current path spends 15s on materialization before facet computation even begins.
+| Materialize all rows | 15s+ (2.5M rows) | **Eliminated** |
+| Extract URIs | ~500ms | **Eliminated** |
+| Build `cts.documentQuery(2.5M URIs)` | Massive plan AST | **Eliminated** |
+| Non-semantic facet (per facet) | ~200ms (join + groupBy) | ~125ms (`fromSearch(ctsQuery)`) |
+| Semantic facet (per facet) | 210-340s (Optic triple chain) | **326ms** (CTS enumerate + estimate) |
 
 ## Optimization 22: annTopK post-filter for HNSW index usage
 

--- a/docs/lux-optic-primer.md
+++ b/docs/lux-optic-primer.md
@@ -127,7 +127,7 @@
     - [Validation results](#validation-results)
       - [Non-semantic facets (`itemTypeId`, 55K matches, `cts.fieldWordQuery('itemAnyText', 'painting')`)](#non-semantic-facets-itemtypeid-55k-matches-ctsfieldwordqueryitemanytext-painting)
       - [Semantic facets (`responsibleCollections`, 2.5M matches)](#semantic-facets-responsiblecollections-25m-matches)
-      - [Performance test results](#performance-test-results)
+      - [Performance test results (2026-07-03)](#performance-test-results-2026-07-03)
     - [Implementation](#implementation)
       - [`performSearch` execution paths (engine.mjs)](#performsearch-execution-paths-enginemjs)
       - [`calculateFacets` dispatch (calculateFacets.mjs)](#calculatefacets-dispatch-calculatefacetsmjs)
@@ -147,6 +147,15 @@
     - [Constraints](#constraints-1)
     - [Open question](#open-question)
     - [Next step](#next-step)
+  - [Optimization 24: HopInverse CTS fast path](#optimization-24-hopinverse-cts-fast-path)
+    - [Problem](#problem-6)
+    - [Why HopInverse cannot use cts.tripleRangeQuery](#why-hopinverse-cannot-use-ctstriplerangequery)
+    - [Approach](#approach-2)
+    - [Implementation](#implementation-1)
+    - [Benchmark](#benchmark-1)
+      - [Single query](#single-query)
+      - [10k performance test (2026-07-05)](#10k-performance-test-2026-07-05)
+    - [Scope and limitations](#scope-and-limitations)
 
 # Introduction
 
@@ -1116,6 +1125,7 @@ Performance opportunities that could be implemented above the backend (mostly).
 | 9 | [Opt 20](#optimization-20-eliminate-fromlexicons-for-join-free-queries) | avoidLexicons: replace `fromLexicons` with `op.fromSearch` + `joinDocAndUri` after pagination. For the reference query, this optimization eliminated 3 lexicon scans (43.9M entries each) and dedup groupBy. Mean dropped from 231% to 31% of CTS (3.2× faster). | 2026-06-28 |
 | 10 | [Opt 22](#optimization-22-anntopk-post-filter-for-hnsw-index-usage) | annTopK post-filter: move scope/self-exclusion filters to after `annTopK` so the HNSW index is used (`indexed="true"`). Pre-filters caused brute-force kNN — 800× slower on 20M vectors. Also extends Opt 20 to skip `fromLexicons` for annTopK-only queries. | 2026-06-29 |
 | 11 | [Opt 21](#optimization-21-cts-native-facet-computation) | CTS-native facet computation: three-way dispatch in `calculateFacets`. Semantic facets use CTS enumerate + estimate (1,044× faster than Optic triple joins at 2.5M scale). Non-semantic facets use `op.fromSearch(scopedCtsQuery)` (32× faster than URI-list approach). Removes facet guard from `isCtsExecutionEligible`, enabling Opt 18/20 when facets are co-requested. Depends on [Opt 15](#optimization-15-cts-fold). | 2026-07-02 |
+| 12 | [Opt 24](#optimization-24-hopinverse-cts-fast-path) | HopInverse CTS fast path: when inner criteria resolves to pure CTS, apply `.where(innerCts)` directly on `fromTriples` instead of building a `fromLexicons` plan and fragment-joining. Eliminates per-hop IRI lexicon scans (~43.9M rows). Representative query: 2,649ms → 121ms (22×). | 2026-07-05 |
 
 ## Data Type Constraint Optimizations
 
@@ -1866,9 +1876,22 @@ Benchmarked on MarkLogic 12.0.1 against the content database. Scripts in `scratc
 
 5. **`responsibleUnits`** has a 3-hop chain with no single denormalized field equivalent. Its CTS config uses `cts.triples` + `cts.documentQuery` nesting to pre-compute candidates — manageable because the enumeration runs once (search-independent) and per-value `cts.estimate` calls use the same field-index intersection pattern.
 
-#### Performance test results
+#### Performance test results (2026-07-03)
 
-TODO: Add 10k performance test results comparing pre-Opt-21 baselines (IDs 22, 26, 30) against Opt 21 enabled.
+Results are of the 19,626 derived facet requests from the 10k-1 search requests.  CTS baseline: 7/2 CTS New 10k-1 with warm caches (14 min). Optic stack: 1, 3, 15, 17, 18, 20, 22 (ID 22, w/o Opt 21) and + 21 (IDs 31/32, w/ Opt 21).
+
+Comparison 22 → 31: adding Opt 21 (Optic-to-Optic).
+
+| Metric | ID 22 (w/o Opt 21) | ID 31 (w/ Opt 21) | Change |
+|---|---|---|---|
+| Test duration | 59 min | 42 min | −29% |
+| Mean (% of CTS) | 290.90% | 203.90% | −22.3% (Optic-to-Optic) |
+| p99.9 (% of CTS) | 71.70% | 2.10% | 1.7× slower → **near parity** |
+| Slowest 20 range (ms) | 7,401–20,158 | 2,319–10,228 | |
+| Requests > 1s | 20 | 20 | unchanged |
+| Functional diff vs CTS | 4,701 | 4,680 | −21 |
+
+Opt 21 substantially improved tail latency: p99.9 dropped from 71.7% above CTS to 2.1% — near parity. The slowest 20 range narrowed from 7.4–20.2s to 2.3–10.2s. However, mean latency remained 2× above CTS (203.9%), and both Optic and CTS had 20 requests over 1s (CTS range: 1,286–3,319ms). The mean gap reflects searches where Opt 21 does not fire (hop/join queries that fall back to Path 3 URI-list facets).
 
 ### Implementation
 
@@ -2056,3 +2079,136 @@ Whether MarkLogic physically materializes a separate HNSW graph per QBV (true pa
 ### Next step
 
 Test `annTopK` against a QBV (e.g., filtered by collection) to determine whether `plan:ann-result indexed="true"` still fires and whether timing improves versus the base view with post-filter.
+
+## Optimization 24: HopInverse CTS fast path
+
+**Status:** Implemented.
+
+**Prerequisite:** [Opt 15 (CTS Fold)](#optimization-15-cts-fold) must be in place — the fold mechanism is what makes inner criteria produce pure-CTS accumulators. [Opt 16 (HopWithField CTS)](#optimization-16-hopwithfield-cts) provides the analogous optimization for `hopWithField` terms; Opt 24 extends the same principle to `hopInverse`.
+
+### Problem
+
+Multi-hop `hopInverse` queries are dominated by intermediate `fromLexicons` scans. Each hop level builds a nested plan via `processNestedCriteria`, which always creates a `fromLexicons({uri, iri, dataType})` plan as the row source. For a 2-hop query like `curated.containingItem.id`, this produces two intermediate `fromLexicons` scans in addition to the top-level scan — each scanning up to 43.9M IRI entries from the lexicon index.
+
+Representative query (`searchWillMatch` for `lux:itemDepartment`):
+```json
+{"curated": {"containingItem": {"id": "https://lux.collections.yale.edu/data/object/..."}}}
+```
+
+Before Opt 24, the plan for this query:
+```javascript
+// Top-level: agent scope
+op.fromLexicons({uri, iri, dataType}).where(dataType in ['Person','Group'])
+  .joinInner(
+    // Outer triple (agentOfCuration)
+    op.fromTriples([pattern(s, agentOfCuration, o, triFrag)])
+      .joinInner(
+        // INTERMEDIATE: set scope — 316K-row lexicon scan
+        op.fromLexicons({set_uri, set_iri, set_dataType}).where(dataType='Set')
+          .joinInner(
+            // Inner triple (member_of)
+            op.fromTriples([pattern(s, member_of, o, triFrag)])
+              .joinInner(
+                // INTERMEDIATE: item scope — 10M+ row lexicon scan
+                op.fromLexicons({item_uri, item_iri, item_dataType})
+                  .where(dataType in ['DigitalObject','HumanMadeObject'])
+                  .where(cts.documentQuery(targetId))
+                  .select([item_iri, item_frag]),     // Opt 17 barrier
+                on(triFrag, item_frag)),              // fragment join
+            on(set_iri, inner_o))
+          .select([set_iri, set_frag]),               // Opt 17 barrier
+        on(triFrag, set_frag)),                       // fragment join
+    on(iri, outer_o))
+```
+
+The two intermediate `fromLexicons` calls — scanning 10M+ and 316K rows respectively — are pure overhead. Their only purpose is to provide an `iri` column and `frag` column for the hop pattern joins, but the `fromTriples` pattern already provides equivalent columns via its subject/object and fragmentIdCol.
+
+### Why HopInverse cannot use cts.tripleRangeQuery
+
+[Opt 16](#optimization-16-hopwithfield-cts) resolves `hopWithField` terms as `cts.tripleRangeQuery` CTS constraints. This works because `hopWithField`'s triple `(parent, predicate, child)` lives on the **parent** document — the one being constrained. `cts.tripleRangeQuery` matches documents containing the specified triple, so the constraint correctly filters the parent scope.
+
+`hopInverse` has the opposite triple direction: `(child, predicate, parent)` where the triple lives on the **child** (referenced) document, not the parent. `cts.tripleRangeQuery` would constrain child documents, not the parent scope the search needs to filter. This means HopInverse cannot fully collapse to a CTS constraint and must retain an Optic `fromTriples` row source to bridge the document boundary.
+
+### Approach
+
+When HopInverse's inner criteria resolves to pure CTS (detected via `processNestedCriteriaAsCts`), apply the CTS query as `.where(innerCts)` directly on the `fromTriples` plan instead of building a separate `fromLexicons` plan and fragment-joining.
+
+After Opt 24, the innermost hop in the example above becomes:
+```javascript
+// Inner triple — no fromLexicons, no fragment join
+op.fromTriples([pattern(s, member_of, o, triFrag)])
+  .where(cts.documentQuery(targetId))       // CTS applied directly
+```
+
+The `.where()` on `fromTriples` constrains which document fragments the triples come from — functionally equivalent to the fragment join against `fromLexicons.where(ctsQuery)`, but without the lexicon scan.
+
+### Implementation
+
+Single change in `HopInverse.mjs` — `apply()` method. Before building the Optic fallback path (`fromTriples.joinInner(processNestedCriteria(...))`), attempt `processNestedCriteriaAsCts`:
+
+```javascript
+const innerCts = scp.processNestedCriteriaAsCts({
+  planCriteria: searchTerm.getCriteria(),
+  planScope: termConfig.getTargetScopeName(),
+  patternOptions: SCP.initializePatternOptions(),
+  parentId: id,
+});
+if (innerCts) {
+  return {
+    patternJoins: [{
+      right: tri.where(innerCts),
+      on: op.on(op.col(parentIriCol), op.col(id + '_o')),
+      extraCols: [],
+    }],
+  };
+}
+```
+
+When `processNestedCriteriaAsCts` returns non-null:
+- The `fromTriples` plan gets a `.where(innerCts)` constraint — no `fromLexicons` needed.
+- The fragment join (`on(triFrag, refFrag)`) is eliminated — the `.where()` directly constrains the triple's source fragments.
+- The outer join key remains `on(parentIriCol, _o)` — unchanged from the original path.
+
+When `processNestedCriteriaAsCts` returns null (inner criteria requires Optic joins), the existing `processNestedCriteria` fallback path fires unchanged.
+
+**Source file:** `src/main/ml-modules/root/lib/search/patterns/HopInverse.mjs`
+
+### Benchmark
+
+#### Single query
+
+Representative query: `{"curated":{"containingItem":{"id":"..."}}}` via `searchWillMatch`.
+
+| Metric | Before Opt 24 | After Opt 24 | Improvement |
+|---|---|---|---|
+| `lux:itemDepartment` latency | 2,649ms | 121ms | 22× |
+| Total batch (6 searches) | 3,127ms | 603ms | 5.2× |
+
+#### 10k performance test (2026-07-05)
+
+10K-document `get-data-no-profile` requests, cleared caches. CTS baseline: 7/4 CTS 10k-docs-no-pro (20 min). Optic stack: 1, 3, 15, 17, 18, 20, 21, 22 (ID 35) + 24 (ID 36).
+
+Before Opt 24 (ID 35), `lux:itemDepartment` (a 2-hop `hopInverse` chain) was the slowest search at 2.9–3.1s (CTS: 522–780ms). All but one of the 20 slowest were item-scope.
+
+Comparison 35 → 36: adding Opt 24.
+
+| Metric | ID 35 (w/o Opt 24) | ID 36 (w/ Opt 24) | Change |
+|---|---|---|---|
+| Test duration | 300 min | 66 min | −78% |
+| Mean (% of CTS) | 1,409.90% | 232.50% | 14× slower → **2.3× slower** |
+| p99.9 (% of CTS) | 662.90% | 46.10% | 6.6× slower → **2.2× faster** |
+| Slowest 20 range (ms) | 4,313–18,403 | 817–1,064 | |
+| Requests > 1s | 20 | 1 | −95% |
+| Functional diff vs CTS | 39 | 38 | −1 |
+
+### Scope and limitations
+
+**What Opt 24 covers:**
+- Any `hopInverse` term whose inner criteria resolves to pure CTS via `processNestedCriteriaAsCts`. This includes direct IRI lookups (`{id: "..."}`, `{iri: "..."}`), field constraints (`{name: "..."}`, `{identifier: "..."}`), and nested criteria composed entirely of CTS-foldable terms.
+
+**What Opt 24 does not cover:**
+- Inner criteria requiring Optic joins (e.g., nested hops that themselves don't resolve to CTS). These fall back to the original `processNestedCriteria` + `fromLexicons` path.
+
+**Cascade behavior:** Opt 24 returns `patternJoins` (not `ctsConstraints`), so it does not cascade through `processNestedCriteriaAsCts` at the parent scope level. For a 2-hop chain like `curated.containingItem.id`, the innermost `fromLexicons` (item scope, ~10M rows) is eliminated, but the middle `fromLexicons` (set scope, ~316K rows) is retained. Despite this single-level limitation, the benchmark shows the optimization is sufficient for the target query shape.
+
+**Relationship to Opt 16:** Opt 16 handles `hopWithField` by emitting `cts.tripleRangeQuery` as a `ctsConstraint`, which DOES cascade — each outer hop also sees only CTS and can resolve without Optic. Opt 24 handles `hopInverse` via a different mechanism (`.where()` on `fromTriples`) because the triple's document location prevents full CTS resolution. The two optimizations are complementary and cover the two hop pattern types.

--- a/src/main/ml-modules/root/config/semanticFacetsConfig.mjs
+++ b/src/main/ml-modules/root/config/semanticFacetsConfig.mjs
@@ -5,6 +5,10 @@ import {
   getPrefixesForSPARQL,
 } from '../lib/search/prefixUtils.mjs';
 
+const crm = op.prefixer('http://www.cidoc-crm.org/cidoc-crm/');
+const la = op.prefixer('https://linked.art/ns/terms/');
+const lux = op.prefixer('https://lux.collections.yale.edu/ns/');
+
 const SEMANTIC_FACETS_CONFIG = {
   responsibleCollections: {
     scope: 'item',
@@ -60,6 +64,17 @@ const SEMANTIC_FACETS_CONFIG = {
       };
       return criteria;
     },
+    // Opt 21: CTS-native semantic facet properties.
+    potentialFacetValuesCtsQuery: cts.andQuery([
+      cts.jsonPropertyValueQuery('dataType', 'Set', ['exact']),
+      cts.jsonPropertyValueQuery('id', IDENTIFIERS.collection, ['exact'], 1),
+    ]),
+    getValuesCountCtsQuery: (baseSearchCtsQuery, facetValueId) => {
+      return cts.andQuery([
+        cts.fieldValueQuery(['itemMemberOfId'], facetValueId, ['exact'], 1),
+        baseSearchCtsQuery,
+      ]);
+    },
   },
   responsibleUnits: {
     scope: 'item',
@@ -98,6 +113,202 @@ const SEMANTIC_FACETS_CONFIG = {
         ],
       };
       return criteria;
+    },
+    // Opt 21: CTS-native semantic facet properties.
+    potentialFacetValuesCtsQuery: cts.andQuery([
+      cts.jsonPropertyValueQuery('dataType', ['Group'], ['exact']),
+      cts.orQuery([
+        cts.andQuery([
+          cts.documentQuery(
+            cts
+              .triples(
+                [],
+                [lux('agentOfCuration')],
+                [],
+                '=',
+                ['eager', 'concurrent'],
+                cts.tripleRangeQuery(
+                  [],
+                  [lux('setClassifiedAs')],
+                  fn.insertBefore(
+                    cts.values(
+                      cts.iriReference(),
+                      '',
+                      ['eager', 'concurrent'],
+                      cts.fieldValueQuery(
+                        ['conceptIdentifier'],
+                        [IDENTIFIERS.collection],
+                        ['exact'],
+                        1,
+                      ),
+                    ),
+                    0,
+                    sem.iri('/does/not/exist'),
+                  ),
+                  '=',
+                  [],
+                  1,
+                ),
+              )
+              .toArray()
+              .map((x) => sem.tripleObject(x))
+              .concat(sem.iri('/does/not/exist')),
+          ),
+          cts.notQuery(
+            cts.andQuery([
+              cts.tripleRangeQuery(
+                [],
+                [lux('agentClassifiedAs')],
+                fn.insertBefore(
+                  cts.values(
+                    cts.iriReference(),
+                    '',
+                    ['eager', 'concurrent'],
+                    cts.fieldValueQuery(
+                      ['conceptIdentifier'],
+                      [IDENTIFIERS.department],
+                      ['exact'],
+                      1,
+                    ),
+                  ),
+                  0,
+                  sem.iri('/does/not/exist'),
+                ),
+                '=',
+                [],
+                1,
+              ),
+            ]),
+          ),
+        ]),
+        cts.andQuery([
+          cts.documentQuery(
+            cts
+              .triples(
+                [],
+                [crm('P107i_is_current_or_former_member_of')],
+                [],
+                '=',
+                ['eager', 'concurrent'],
+                cts.andQuery([
+                  cts.tripleRangeQuery(
+                    [],
+                    [lux('agentClassifiedAs')],
+                    fn.insertBefore(
+                      cts.values(
+                        cts.iriReference(),
+                        '',
+                        ['eager', 'concurrent'],
+                        cts.fieldValueQuery(
+                          ['conceptIdentifier'],
+                          [IDENTIFIERS.department],
+                          ['exact'],
+                          1,
+                        ),
+                      ),
+                      0,
+                      sem.iri('/does/not/exist'),
+                    ),
+                    '=',
+                    [],
+                    1,
+                  ),
+                  cts.documentQuery(
+                    cts
+                      .triples(
+                        [],
+                        [lux('agentOfCuration')],
+                        [],
+                        '=',
+                        ['eager', 'concurrent'],
+                        cts.tripleRangeQuery(
+                          [],
+                          [lux('setClassifiedAs')],
+                          fn.insertBefore(
+                            cts.values(
+                              cts.iriReference(),
+                              '',
+                              ['eager', 'concurrent'],
+                              cts.fieldValueQuery(
+                                ['conceptIdentifier'],
+                                [IDENTIFIERS.collection],
+                                ['exact'],
+                                1,
+                              ),
+                            ),
+                            0,
+                            sem.iri('/does/not/exist'),
+                          ),
+                          '=',
+                          [],
+                          1,
+                        ),
+                      )
+                      .toArray()
+                      .map((x) => sem.tripleObject(x))
+                      .concat(sem.iri('/does/not/exist')),
+                  ),
+                ]),
+              )
+              .toArray()
+              .map((x) => sem.tripleObject(x))
+              .concat(sem.iri('/does/not/exist')),
+          ),
+        ]),
+      ]),
+    ]),
+    getValuesCountCtsQuery: (baseSearchCtsQuery, facetValueId) => {
+      return cts.andQuery([
+        cts.andQuery([
+          cts.jsonPropertyValueQuery(
+            'dataType',
+            ['DigitalObject', 'HumanMadeObject', 'Set'],
+            ['exact'],
+          ),
+          cts.tripleRangeQuery(
+            [],
+            [la('member_of')],
+            fn.insertBefore(
+              cts.values(
+                cts.iriReference(),
+                '',
+                ['eager', 'concurrent'],
+                cts.tripleRangeQuery(
+                  [],
+                  [lux('agentOfCuration')],
+                  fn.insertBefore(
+                    cts.values(
+                      cts.iriReference(),
+                      '',
+                      ['eager', 'concurrent'],
+                      cts.orQuery([
+                        cts.fieldValueQuery(
+                          ['agentMemberOfId'],
+                          [facetValueId],
+                          ['exact'],
+                          1,
+                        ),
+                        cts.documentQuery([facetValueId]),
+                      ]),
+                    ),
+                    0,
+                    sem.iri('/does/not/exist'),
+                  ),
+                  '=',
+                  [],
+                  1,
+                ),
+              ),
+              0,
+              sem.iri('/does/not/exist'),
+            ),
+            '=',
+            [],
+            1,
+          ),
+        ]),
+        baseSearchCtsQuery,
+      ]);
     },
   },
 };

--- a/src/main/ml-modules/root/config/semanticFacetsConfig.mjs
+++ b/src/main/ml-modules/root/config/semanticFacetsConfig.mjs
@@ -65,10 +65,11 @@ const SEMANTIC_FACETS_CONFIG = {
       return criteria;
     },
     // Opt 21: CTS-native semantic facet properties.
-    potentialFacetValuesCtsQuery: cts.andQuery([
-      cts.jsonPropertyValueQuery('dataType', 'Set', ['exact']),
-      cts.jsonPropertyValueQuery('id', IDENTIFIERS.collection, ['exact'], 1),
-    ]),
+    potentialFacetValuesCtsQuery: () =>
+      cts.andQuery([
+        cts.jsonPropertyValueQuery('dataType', 'Set', ['exact']),
+        cts.jsonPropertyValueQuery('id', IDENTIFIERS.collection, ['exact'], 1),
+      ]),
     getValuesCountCtsQuery: (baseSearchCtsQuery, facetValueId) => {
       return cts.andQuery([
         cts.fieldValueQuery(['itemMemberOfId'], facetValueId, ['exact'], 1),
@@ -115,85 +116,22 @@ const SEMANTIC_FACETS_CONFIG = {
       return criteria;
     },
     // Opt 21: CTS-native semantic facet properties.
-    potentialFacetValuesCtsQuery: cts.andQuery([
-      cts.jsonPropertyValueQuery('dataType', ['Group'], ['exact']),
-      cts.orQuery([
-        cts.andQuery([
-          cts.documentQuery(
-            cts
-              .triples(
-                [],
-                [lux('agentOfCuration')],
-                [],
-                '=',
-                ['eager', 'concurrent'],
-                cts.tripleRangeQuery(
+    potentialFacetValuesCtsQuery: () =>
+      cts.andQuery([
+        cts.jsonPropertyValueQuery('dataType', ['Group'], ['exact']),
+        cts.orQuery([
+          cts.andQuery([
+            cts.documentQuery(
+              cts
+                .triples(
                   [],
-                  [lux('setClassifiedAs')],
-                  fn.insertBefore(
-                    cts.values(
-                      cts.iriReference(),
-                      '',
-                      ['eager', 'concurrent'],
-                      cts.fieldValueQuery(
-                        ['conceptIdentifier'],
-                        [IDENTIFIERS.collection],
-                        ['exact'],
-                        1,
-                      ),
-                    ),
-                    0,
-                    sem.iri('/does/not/exist'),
-                  ),
+                  [lux('agentOfCuration')],
+                  [],
                   '=',
-                  [],
-                  1,
-                ),
-              )
-              .toArray()
-              .map((x) => sem.tripleObject(x))
-              .concat(sem.iri('/does/not/exist')),
-          ),
-          cts.notQuery(
-            cts.andQuery([
-              cts.tripleRangeQuery(
-                [],
-                [lux('agentClassifiedAs')],
-                fn.insertBefore(
-                  cts.values(
-                    cts.iriReference(),
-                    '',
-                    ['eager', 'concurrent'],
-                    cts.fieldValueQuery(
-                      ['conceptIdentifier'],
-                      [IDENTIFIERS.department],
-                      ['exact'],
-                      1,
-                    ),
-                  ),
-                  0,
-                  sem.iri('/does/not/exist'),
-                ),
-                '=',
-                [],
-                1,
-              ),
-            ]),
-          ),
-        ]),
-        cts.andQuery([
-          cts.documentQuery(
-            cts
-              .triples(
-                [],
-                [crm('P107i_is_current_or_former_member_of')],
-                [],
-                '=',
-                ['eager', 'concurrent'],
-                cts.andQuery([
+                  ['eager', 'concurrent'],
                   cts.tripleRangeQuery(
                     [],
-                    [lux('agentClassifiedAs')],
+                    [lux('setClassifiedAs')],
                     fn.insertBefore(
                       cts.values(
                         cts.iriReference(),
@@ -201,7 +139,7 @@ const SEMANTIC_FACETS_CONFIG = {
                         ['eager', 'concurrent'],
                         cts.fieldValueQuery(
                           ['conceptIdentifier'],
-                          [IDENTIFIERS.department],
+                          [IDENTIFIERS.collection],
                           ['exact'],
                           1,
                         ),
@@ -213,50 +151,114 @@ const SEMANTIC_FACETS_CONFIG = {
                     [],
                     1,
                   ),
-                  cts.documentQuery(
-                    cts
-                      .triples(
-                        [],
-                        [lux('agentOfCuration')],
-                        [],
-                        '=',
-                        ['eager', 'concurrent'],
-                        cts.tripleRangeQuery(
-                          [],
-                          [lux('setClassifiedAs')],
-                          fn.insertBefore(
-                            cts.values(
-                              cts.iriReference(),
-                              '',
-                              ['eager', 'concurrent'],
-                              cts.fieldValueQuery(
-                                ['conceptIdentifier'],
-                                [IDENTIFIERS.collection],
-                                ['exact'],
-                                1,
-                              ),
-                            ),
-                            0,
-                            sem.iri('/does/not/exist'),
-                          ),
-                          '=',
-                          [],
-                          1,
-                        ),
-                      )
-                      .toArray()
-                      .map((x) => sem.tripleObject(x))
-                      .concat(sem.iri('/does/not/exist')),
+                )
+                .toArray()
+                .map((x) => sem.tripleObject(x))
+                .concat(sem.iri('/does/not/exist')),
+            ),
+            cts.notQuery(
+              cts.andQuery([
+                cts.tripleRangeQuery(
+                  [],
+                  [lux('agentClassifiedAs')],
+                  fn.insertBefore(
+                    cts.values(
+                      cts.iriReference(),
+                      '',
+                      ['eager', 'concurrent'],
+                      cts.fieldValueQuery(
+                        ['conceptIdentifier'],
+                        [IDENTIFIERS.department],
+                        ['exact'],
+                        1,
+                      ),
+                    ),
+                    0,
+                    sem.iri('/does/not/exist'),
                   ),
-                ]),
-              )
-              .toArray()
-              .map((x) => sem.tripleObject(x))
-              .concat(sem.iri('/does/not/exist')),
-          ),
+                  '=',
+                  [],
+                  1,
+                ),
+              ]),
+            ),
+          ]),
+          cts.andQuery([
+            cts.documentQuery(
+              cts
+                .triples(
+                  [],
+                  [crm('P107i_is_current_or_former_member_of')],
+                  [],
+                  '=',
+                  ['eager', 'concurrent'],
+                  cts.andQuery([
+                    cts.tripleRangeQuery(
+                      [],
+                      [lux('agentClassifiedAs')],
+                      fn.insertBefore(
+                        cts.values(
+                          cts.iriReference(),
+                          '',
+                          ['eager', 'concurrent'],
+                          cts.fieldValueQuery(
+                            ['conceptIdentifier'],
+                            [IDENTIFIERS.department],
+                            ['exact'],
+                            1,
+                          ),
+                        ),
+                        0,
+                        sem.iri('/does/not/exist'),
+                      ),
+                      '=',
+                      [],
+                      1,
+                    ),
+                    cts.documentQuery(
+                      cts
+                        .triples(
+                          [],
+                          [lux('agentOfCuration')],
+                          [],
+                          '=',
+                          ['eager', 'concurrent'],
+                          cts.tripleRangeQuery(
+                            [],
+                            [lux('setClassifiedAs')],
+                            fn.insertBefore(
+                              cts.values(
+                                cts.iriReference(),
+                                '',
+                                ['eager', 'concurrent'],
+                                cts.fieldValueQuery(
+                                  ['conceptIdentifier'],
+                                  [IDENTIFIERS.collection],
+                                  ['exact'],
+                                  1,
+                                ),
+                              ),
+                              0,
+                              sem.iri('/does/not/exist'),
+                            ),
+                            '=',
+                            [],
+                            1,
+                          ),
+                        )
+                        .toArray()
+                        .map((x) => sem.tripleObject(x))
+                        .concat(sem.iri('/does/not/exist')),
+                    ),
+                  ]),
+                )
+                .toArray()
+                .map((x) => sem.tripleObject(x))
+                .concat(sem.iri('/does/not/exist')),
+            ),
+          ]),
         ]),
       ]),
-    ]),
     getValuesCountCtsQuery: (baseSearchCtsQuery, facetValueId) => {
       return cts.andQuery([
         cts.andQuery([

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -1,0 +1,266 @@
+'use strict';
+
+// Facet computation module — owns the three-way dispatch for calculating
+// facet values and counts from search results or a CTS query.
+//
+// Paths:
+//   1. CTS + semantic  → enumerate candidates via cts.search, count via cts.estimate
+//   2. CTS + non-semantic → op.fromSearch(scopedCtsQuery) + Optic join/groupBy
+//   3. No CTS (non-foldable) → op.fromSearch(cts.documentQuery(uriList)) + Optic join/groupBy
+
+import op from '/MarkLogic/optic.mjs';
+import { FACETS_CONFIG } from '../../config/facetsConfig.mjs';
+import { SEMANTIC_FACETS_CONFIG } from '../../config/semanticFacetsConfig.mjs';
+import { isSemanticFacet } from '../facetsLib.mjs';
+import { convertSecondsToDateStr } from '../../utils/dateUtils.mjs';
+import * as utils from '../../utils/utils.mjs';
+import {
+  InternalServerError,
+  InvalidSearchRequestError,
+} from '../errorClasses.mjs';
+import { FacetResponses } from './FacetResponses.mjs';
+
+const SEMANTIC_VALUE_LIMIT = 100;
+
+// Main entry point. Called by performSearch in engine.mjs.
+//
+// When scopedCtsQuery is non-null (join-free accumulator):
+//   - Semantic facets use CTS enumerate-and-estimate (Path 1).
+//   - Non-semantic facets use op.fromSearch(scopedCtsQuery) (Path 2).
+// When scopedCtsQuery is null (non-foldable query):
+//   - All facets use op.fromSearch(cts.documentQuery(uriList)) (Path 3).
+//   - rows must be non-null.
+function calculateFacets(rows, facetRequests, scopedCtsQuery = null) {
+  if (facetRequests == null || facetRequests.length === 0) {
+    return null;
+  }
+
+  const requests = facetRequests.getFacetRequests();
+  if (!utils.isNonEmptyArray(requests)) {
+    return new FacetResponses({});
+  }
+
+  // Path 3 setup: extract URIs from materialized rows.
+  let uriList = null;
+  if (!scopedCtsQuery) {
+    uriList = rows.map((row) => row.id);
+    if (!utils.isNonEmptyArray(uriList)) {
+      return _buildEmptyFacetResponses(requests);
+    }
+  }
+
+  const page = facetRequests.getPage() ?? 1;
+  const pageLength = facetRequests.getPageLength() ?? 20;
+  const start = (page - 1) * pageLength;
+  const end = page * pageLength;
+
+  const facets = {};
+  requests.forEach((request) => {
+    const facetName = request?.name;
+
+    if (isSemanticFacet(facetName) && scopedCtsQuery) {
+      // Path 1: CTS enumerate + estimate.
+      facets[facetName] = _calculateSemanticFacetViaCts(
+        facetName,
+        scopedCtsQuery,
+        start,
+        end,
+      );
+    } else {
+      // Path 2 or 3: Optic join.
+      const docsPlan = scopedCtsQuery
+        ? op.fromSearch(scopedCtsQuery)
+        : op.fromSearch(cts.documentQuery(uriList));
+
+      facets[facetName] = _calculateFacetViaOptic(
+        facetName,
+        docsPlan,
+        request,
+        start,
+        end,
+      );
+    }
+  });
+
+  return new FacetResponses(facets);
+}
+
+// Path 1: CTS-native semantic facet computation.
+// Enumerates candidate facet values via cts.search (search-independent),
+// then counts per candidate via cts.estimate (pure index intersection).
+function _calculateSemanticFacetViaCts(facetName, scopedCtsQuery, start, end) {
+  const semanticConfig = _getValidatedSemanticFacetConfig(facetName);
+
+  if (!semanticConfig.potentialFacetValuesCtsQuery) {
+    throw new InternalServerError(
+      `Semantic facet '${facetName}' is misconfigured: missing 'potentialFacetValuesCtsQuery' (required for CTS path).`,
+    );
+  }
+  if (typeof semanticConfig.getValuesCountCtsQuery !== 'function') {
+    throw new InternalServerError(
+      `Semantic facet '${facetName}' is misconfigured: missing 'getValuesCountCtsQuery' function (required for CTS path).`,
+    );
+  }
+
+  const potentialFacetValues = fn
+    .subsequence(
+      cts.search(semanticConfig.potentialFacetValuesCtsQuery, [
+        'unfiltered',
+        'unfaceted',
+        'score-zero',
+      ]),
+      1,
+      SEMANTIC_VALUE_LIMIT + 1,
+    )
+    .toArray();
+
+  if (potentialFacetValues.length > SEMANTIC_VALUE_LIMIT) {
+    console.warn(
+      `The '${facetName}' semantic facet exceeded the ${SEMANTIC_VALUE_LIMIT} value limit.`,
+    );
+    potentialFacetValues.length = SEMANTIC_VALUE_LIMIT;
+  }
+
+  const facetValues = potentialFacetValues
+    .map((doc) => {
+      const uri = doc.baseURI;
+      return {
+        value: uri,
+        count: cts.estimate(
+          semanticConfig.getValuesCountCtsQuery(scopedCtsQuery, uri),
+        ),
+      };
+    })
+    .filter((result) => result.count > 0)
+    .sort((a, b) => b.count - a.count);
+
+  return {
+    totalItems: facetValues.length,
+    facetValues: facetValues.slice(start, end),
+  };
+}
+
+// Path 2 and 3: Optic-based facet computation (semantic and non-semantic).
+function _calculateFacetViaOptic(facetName, docsPlan, request, start, end) {
+  let facetSourcePlan = docsPlan;
+
+  let constraintPlan;
+  let joinOn;
+  let facetValueColName = 'value';
+  let countColName = 'uri';
+
+  if (isSemanticFacet(facetName)) {
+    const semanticConfig = _getValidatedSemanticFacetConfig(facetName);
+    facetValueColName = semanticConfig.facetValueColName;
+    countColName = semanticConfig.constraintJoinColName;
+    const sourceJoinColName = semanticConfig.sourceJoinColName;
+
+    if (sourceJoinColName === 'iri') {
+      facetSourcePlan = facetSourcePlan.joinInner(
+        op.fromLexicons(
+          { iri: cts.iriReference() },
+          null,
+          op.fragmentIdCol('iriFragId'),
+        ),
+        op.on('fragmentId', 'iriFragId'),
+      );
+    }
+
+    // Projection barrier helps avoid optimizer paths that can collapse
+    // certain semantic joins to zero rows.
+    facetSourcePlan = facetSourcePlan.select([sourceJoinColName]);
+
+    constraintPlan = semanticConfig.plan;
+    joinOn = op.on(sourceJoinColName, countColName);
+  } else {
+    const indexReference = FACETS_CONFIG[facetName].indexReference;
+    if (!utils.isNonEmptyString(indexReference)) {
+      throw new InvalidSearchRequestError(
+        `The '${facetName}' facet is not currently supported for this operation.`,
+      );
+    }
+
+    constraintPlan = op.fromLexicons(
+      {
+        [facetValueColName]: cts.fieldReference(indexReference),
+        [countColName]: cts.uriReference(),
+      },
+      null,
+      op.fragmentIdCol('lexFragId'),
+    );
+    joinOn = op.on('fragmentId', 'lexFragId');
+  }
+
+  const isDateFacet = facetName.endsWith('Date');
+  const sort = request?.sort;
+  const rows = facetSourcePlan
+    .joinInner(constraintPlan, joinOn)
+    .groupBy(op.col(facetValueColName), op.count('count', countColName))
+    .orderBy(
+      sort === 'desc'
+        ? op.desc(facetValueColName)
+        : sort === 'asc'
+          ? op.asc(facetValueColName)
+          : op.desc('count'),
+    )
+    .result()
+    .toArray();
+
+  return {
+    totalItems: rows.length,
+    facetValues: rows.slice(start, end).map((row) => {
+      const rawValue = row[facetValueColName];
+      return {
+        value: isDateFacet ? convertSecondsToDateStr(rawValue) : rawValue,
+        count: row.count,
+      };
+    }),
+  };
+}
+
+function _getValidatedSemanticFacetConfig(facetName) {
+  const semanticConfig = SEMANTIC_FACETS_CONFIG[facetName];
+  const sourceJoinColName = semanticConfig?.sourceJoinColName;
+  const constraintJoinColName = semanticConfig?.constraintJoinColName;
+
+  if (!utils.isNonEmptyString(sourceJoinColName)) {
+    throw new InternalServerError(
+      `Semantic facet '${facetName}' is misconfigured: missing required 'sourceJoinColName'.`,
+    );
+  }
+  if (!utils.isNonEmptyString(constraintJoinColName)) {
+    throw new InternalServerError(
+      `Semantic facet '${facetName}' is misconfigured: missing required 'constraintJoinColName'.`,
+    );
+  }
+
+  const planValue = semanticConfig?.plan;
+  const validPlanType =
+    typeof planValue?.result === 'function' &&
+    typeof planValue?.export === 'function';
+  if (!validPlanType) {
+    throw new InternalServerError(
+      `Semantic facet '${facetName}' is misconfigured: 'plan' is required and must be an Optic plan.`,
+    );
+  }
+
+  return {
+    ...semanticConfig,
+    sourceJoinColName,
+    constraintJoinColName,
+  };
+}
+
+function _buildEmptyFacetResponses(requests) {
+  const facets = {};
+  requests.forEach((request) => {
+    const facetName = request?.name;
+    facets[facetName] = {
+      totalItems: 0,
+      facetValues: [],
+    };
+  });
+  return new FacetResponses(facets);
+}
+
+export { calculateFacets };

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -91,9 +91,9 @@ function calculateFacets(rows, facetRequests, scopedCtsQuery = null) {
 function _calculateSemanticFacetViaCts(facetName, scopedCtsQuery, start, end) {
   const semanticConfig = _getValidatedSemanticFacetConfig(facetName);
 
-  if (!semanticConfig.potentialFacetValuesCtsQuery) {
+  if (typeof semanticConfig.potentialFacetValuesCtsQuery !== 'function') {
     throw new InternalServerError(
-      `Semantic facet '${facetName}' is misconfigured: missing 'potentialFacetValuesCtsQuery' (required for CTS path).`,
+      `Semantic facet '${facetName}' is misconfigured: missing 'potentialFacetValuesCtsQuery' function (required for CTS path).`,
     );
   }
   if (typeof semanticConfig.getValuesCountCtsQuery !== 'function') {
@@ -104,7 +104,7 @@ function _calculateSemanticFacetViaCts(facetName, scopedCtsQuery, start, end) {
 
   const potentialFacetValues = fn
     .subsequence(
-      cts.search(semanticConfig.potentialFacetValuesCtsQuery, [
+      cts.search(semanticConfig.potentialFacetValuesCtsQuery(), [
         'unfiltered',
         'unfaceted',
         'score-zero',

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -195,6 +195,8 @@ function _calculateFacetViaOptic(facetName, docsPlan, request, start, end) {
   const sort = request?.sort;
   const rows = facetSourcePlan
     .joinInner(constraintPlan, joinOn)
+    // The first groupBy ensures each facet value is only counted once per doc.
+    .groupBy([op.col(countColName), op.col(facetValueColName)])
     .groupBy(op.col(facetValueColName), op.count('count', countColName))
     .orderBy(
       sort === 'desc'

--- a/src/main/ml-modules/root/lib/search/engine.mjs
+++ b/src/main/ml-modules/root/lib/search/engine.mjs
@@ -4,20 +4,16 @@
 import op from '/MarkLogic/optic.mjs';
 import { getSearchScopeTypes } from '../searchScope.mjs';
 import * as utils from '../../utils/utils.mjs';
-import { FACETS_CONFIG } from '../../config/facetsConfig.mjs';
-import { SEMANTIC_FACETS_CONFIG } from '../../config/semanticFacetsConfig.mjs';
-import { isSemanticFacet } from '../facetsLib.mjs';
-import { convertSecondsToDateStr } from '../../utils/dateUtils.mjs';
 import { SEMANTIC_SORT_TIMEOUT } from '../appConstants.mjs';
 import {
   InternalServerError,
   InvalidSearchRequestError,
 } from '../errorClasses.mjs';
-import { FacetResponses } from './FacetResponses.mjs';
 import { SearchExecutionResult } from './SearchExecutionResult.mjs';
 import { expandPredicate } from './prefixUtils.mjs';
 import { NODE_TYPE_GROUP } from './criteriaNodes.mjs';
 import { analyzeCriteria } from './analyzeCriteria.mjs';
+import { calculateFacets } from './calculateFacets.mjs';
 //#endregion
 
 //#region Constants
@@ -97,12 +93,12 @@ function performSearch(scp) {
         patternOptions,
         includeSearchResults,
         pageWith,
-        facetRequests,
       });
 
       planAsJson = selectedPlan.export();
       planAsSource = getPlanSource(planAsJson);
 
+      let rows = null;
       if (ctsExecutionEligible) {
         const effectivePageLength = pageLength ?? 20;
         total = cts.estimate(scopedCtsQuery);
@@ -130,8 +126,10 @@ function performSearch(scp) {
             .result()
             .toArray();
         }
+      } else if (!includeSearchResults && scopedCtsQuery) {
+        // Opt 21: facet-only request with CTS query — skip materialization.
       } else {
-        const rows = selectedPlan.result().toArray();
+        rows = selectedPlan.result().toArray();
 
         if (includeSearchResults) {
           total = rows.length;
@@ -144,10 +142,10 @@ function performSearch(scp) {
           resultPage = paginationResult.resultPage;
           searchResults = paginationResult.searchResults;
         }
-
-        // calculateFacets returns null when facets are not requested.
-        facetResponses = calculateFacets(rows, facetRequests);
       }
+
+      // Opt 21: calculateFacets dispatches internally based on rows/scopedCtsQuery.
+      facetResponses = calculateFacets(rows, facetRequests, scopedCtsQuery);
     }
 
     return new SearchExecutionResult({
@@ -271,8 +269,8 @@ function getResultRowGrouping() {
 // unsorted plans with finalization and optional sort applied.
 // Accepts either a pre-computed analysis result or raw criteria params.
 //
-// When request context is provided (includeSearchResults, pageWith,
-// facetRequests), buildPlans also selects the appropriate plan and determines
+// When request context is provided (includeSearchResults, pageWith),
+// buildPlans also selects the appropriate plan and determines
 // the execution strategy. This keeps plan-shape decisions in Pass 2 rather
 // than scattering them across the executor.
 function buildPlans({
@@ -287,7 +285,6 @@ function buildPlans({
   // Optional request context — when provided, enables strategy determination.
   includeSearchResults = null,
   pageWith = null,
-  facetRequests = null,
 }) {
   // performSearch always provides the analysis but there are other callers that do not.
   const analysis =
@@ -357,7 +354,6 @@ function buildPlans({
     ctsExecutionEligible = isCtsExecutionEligible({
       includeSearchResults,
       pageWith,
-      facetRequests,
       scopedCtsQuery,
     });
 
@@ -933,18 +929,13 @@ function buildScopedCtsQuery(acc, assemblyContext, scope) {
 // execution: cts.estimate for count, offset/limit for pagination, and
 // (with Opt 20) fromSearch instead of fromLexicons for page results.
 // Requires the accumulator to be join-free (CTS-foldable).
+// Facets are compatible: calculateFacets works directly with scopedCtsQuery.
 function isCtsExecutionEligible({
   includeSearchResults,
   pageWith,
-  facetRequests,
   scopedCtsQuery,
 }) {
-  return (
-    includeSearchResults &&
-    !pageWith &&
-    !facetRequests?.length &&
-    scopedCtsQuery != null
-  );
+  return includeSearchResults && !pageWith && scopedCtsQuery != null;
 }
 
 // Returns true when the active sort strategy requires lexicon columns
@@ -989,169 +980,6 @@ function buildFromSearchPlan(
   // No hydration here — performSearch applies .offset().limit() first,
   // then chains .joinDocAndUri() so only the page slice hits disk.
   return plan;
-}
-//#endregion
-
-//#region Facets
-function calculateFacets(rows, facetRequests) {
-  if (facetRequests == null || facetRequests.length === 0) {
-    return null;
-  }
-
-  const requests = facetRequests.getFacetRequests();
-  if (!utils.isNonEmptyArray(requests)) {
-    return new FacetResponses({});
-  }
-
-  const uriList = rows.map((row) => row.id);
-  if (!utils.isNonEmptyArray(uriList)) {
-    return buildEmptyFacetResponses(requests);
-  }
-
-  const page = facetRequests.getPage() ?? 1;
-  const pageLength = facetRequests.getPageLength() ?? 20;
-  const start = (page - 1) * pageLength;
-  const end = page * pageLength;
-  const docsPlan = op.fromSearch(cts.documentQuery(uriList));
-
-  const semanticConfigsByFacetName = {};
-  requests.forEach((request) => {
-    const facetName = request?.name;
-    if (isSemanticFacet(facetName)) {
-      semanticConfigsByFacetName[facetName] =
-        getValidatedSemanticFacetConfig(facetName);
-    }
-  });
-
-  // Optimization idea: try [plan].facetBy, which is a convenience wrapper for groupToArrays.
-  const facets = {};
-  requests.forEach((request) => {
-    const facetName = request?.name;
-    let facetSourcePlan = docsPlan;
-
-    let constraintPlan;
-    let joinOn;
-    let facetValueColName = 'value';
-    let countColName = 'uri';
-    // isSemanticFacet throws if neither semantic nor non-semantic facet
-    if (isSemanticFacet(facetName)) {
-      const semanticConfig = semanticConfigsByFacetName[facetName];
-      facetValueColName = semanticConfig.facetValueColName;
-      countColName = semanticConfig.constraintJoinColName;
-      const sourceJoinColName = semanticConfig.sourceJoinColName;
-
-      if (sourceJoinColName === 'iri') {
-        facetSourcePlan = facetSourcePlan.joinInner(
-          op.fromLexicons(
-            { iri: cts.iriReference() },
-            null,
-            op.fragmentIdCol('iriFragId'),
-          ),
-          op.on('fragmentId', 'iriFragId'),
-        );
-      }
-
-      // Projection barrier helps avoid optimizer paths that can collapse
-      // certain semantic joins to zero rows.
-      facetSourcePlan = facetSourcePlan.select([sourceJoinColName]);
-
-      constraintPlan = semanticConfig.plan;
-
-      joinOn = op.on(sourceJoinColName, countColName);
-    } else {
-      const indexReference = FACETS_CONFIG[facetName].indexReference;
-      if (!utils.isNonEmptyString(indexReference)) {
-        throw new InvalidSearchRequestError(
-          `The '${facetName}' facet is not currently supported for this operation.`,
-        );
-      }
-
-      constraintPlan = op.fromLexicons(
-        {
-          [facetValueColName]: cts.fieldReference(indexReference),
-          [countColName]: cts.uriReference(),
-        },
-        null,
-        op.fragmentIdCol('lexFragId'),
-      );
-      joinOn = op.on('fragmentId', 'lexFragId');
-    }
-
-    const isDateFacet = facetName.endsWith('Date');
-    const sort = request?.sort;
-    const rows = facetSourcePlan
-      .joinInner(constraintPlan, joinOn)
-      .groupBy(op.col(facetValueColName), op.count('count', countColName))
-      .orderBy(
-        sort === 'desc'
-          ? op.desc(facetValueColName)
-          : sort === 'asc'
-            ? op.asc(facetValueColName)
-            : op.desc('count'), // a.k.a. frequency-order
-      )
-      .result()
-      .toArray();
-
-    facets[facetName] = {
-      totalItems: rows.length,
-      facetValues: rows.slice(start, end).map((row) => {
-        const rawValue = row[facetValueColName];
-        return {
-          value: isDateFacet ? convertSecondsToDateStr(rawValue) : rawValue,
-          count: row.count,
-        };
-      }),
-    };
-  });
-
-  return new FacetResponses(facets);
-}
-
-function getValidatedSemanticFacetConfig(facetName) {
-  const semanticConfig = SEMANTIC_FACETS_CONFIG[facetName];
-  const sourceJoinColName = semanticConfig?.sourceJoinColName;
-  const constraintJoinColName = semanticConfig?.constraintJoinColName;
-
-  if (!utils.isNonEmptyString(sourceJoinColName)) {
-    throw new InternalServerError(
-      `Semantic facet '${facetName}' is misconfigured: missing required 'sourceJoinColName'.`,
-    );
-  }
-  if (!utils.isNonEmptyString(constraintJoinColName)) {
-    throw new InternalServerError(
-      `Semantic facet '${facetName}' is misconfigured: missing required 'constraintJoinColName'.`,
-    );
-  }
-
-  const planValue = semanticConfig?.plan;
-  const validPlanType =
-    typeof planValue?.result === 'function' &&
-    typeof planValue?.export === 'function';
-  if (!validPlanType) {
-    throw new InternalServerError(
-      `Semantic facet '${facetName}' is misconfigured: 'plan' is required and must be an Optic plan.`,
-    );
-  }
-
-  return {
-    ...semanticConfig,
-    sourceJoinColName,
-    constraintJoinColName,
-  };
-}
-
-function buildEmptyFacetResponses(requests) {
-  const facets = {};
-
-  requests.forEach((request) => {
-    const facetName = request?.name;
-    facets[facetName] = {
-      totalItems: 0,
-      facetValues: [],
-    };
-  });
-
-  return new FacetResponses(facets);
 }
 //#endregion
 

--- a/src/main/ml-modules/root/lib/search/patterns/HopInverse.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/HopInverse.mjs
@@ -26,13 +26,6 @@ class HopInverse extends SearchPatternBase {
       return this.#processValuesOnly(scp, searchTerm, patternOptions);
     }
 
-    // TODO, PERF: Potential optimization.  When the child criteria is a literal IRI
-    // (same condition #processValuesOnly checks), both hops could be resolved via
-    // cts.triples and injected as op.fromLiterals, avoiding the inner
-    // processNestedCriteria call.  This path only compiles one plan, but it could
-    // still matter for latency-sensitive queries.  Consider prototyping if
-    // profiling shows the inner plan construction is a bottleneck.
-
     const tri = op.fromTriples([
       op.pattern(
         op.col(id + '_s'),
@@ -42,6 +35,29 @@ class HopInverse extends SearchPatternBase {
       ),
     ]);
 
+    // Opt 24: when inner criteria resolves to pure CTS, apply it as .where()
+    // directly on fromTriples instead of building a fromLexicons plan and
+    // joining on fragment. Eliminates the intermediate IRI lexicon scan
+    // (~43.9M rows) that dominates multi-hop query cost.
+    const innerCts = scp.processNestedCriteriaAsCts({
+      planCriteria: searchTerm.getCriteria(),
+      planScope: termConfig.getTargetScopeName(),
+      patternOptions: SCP.initializePatternOptions(),
+      parentId: id,
+    });
+    if (innerCts) {
+      return {
+        patternJoins: [
+          {
+            right: tri.where(innerCts),
+            on: op.on(op.col(parentIriCol), op.col(id + '_o')),
+            extraCols: [],
+          },
+        ],
+      };
+    }
+
+    // Fallback: Optic join path (when inner criteria requires joins).
     const right = tri.joinInner(
       scp.processNestedCriteria({
         planCriteria: searchTerm.getCriteria(),

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0601 isCtsExecutionEligible.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0601 isCtsExecutionEligible.mjs
@@ -13,27 +13,16 @@ const scenarios = [
     input: {
       includeSearchResults: true,
       pageWith: null,
-      facetRequests: null,
       scopedCtsQuery: MOCK_ESTIMATE_QUERY,
     },
     expected: true,
   },
   {
-    name: 'facetRequests is empty array',
+    name: 'facets co-requested (Opt 21 removed facet guard)',
     input: {
       includeSearchResults: true,
       pageWith: null,
-      facetRequests: [],
-      scopedCtsQuery: MOCK_ESTIMATE_QUERY,
-    },
-    expected: true,
-  },
-  {
-    name: 'facetRequests is undefined',
-    input: {
-      includeSearchResults: true,
-      pageWith: null,
-      facetRequests: undefined,
+      facetRequests: [{ name: 'responsibleUnits' }],
       scopedCtsQuery: MOCK_ESTIMATE_QUERY,
     },
     expected: true,
@@ -45,7 +34,6 @@ const scenarios = [
     input: {
       includeSearchResults: false,
       pageWith: null,
-      facetRequests: null,
       scopedCtsQuery: MOCK_ESTIMATE_QUERY,
     },
     expected: false,
@@ -55,17 +43,6 @@ const scenarios = [
     input: {
       includeSearchResults: true,
       pageWith: 'https://example.com/doc/1',
-      facetRequests: null,
-      scopedCtsQuery: MOCK_ESTIMATE_QUERY,
-    },
-    expected: false,
-  },
-  {
-    name: 'facetRequests has entries',
-    input: {
-      includeSearchResults: true,
-      pageWith: null,
-      facetRequests: [{ name: 'responsibleUnits' }],
       scopedCtsQuery: MOCK_ESTIMATE_QUERY,
     },
     expected: false,
@@ -75,7 +52,6 @@ const scenarios = [
     input: {
       includeSearchResults: true,
       pageWith: null,
-      facetRequests: null,
       scopedCtsQuery: null,
     },
     expected: false,
@@ -87,17 +63,15 @@ const scenarios = [
     input: {
       includeSearchResults: true,
       pageWith: 'https://example.com/doc/1',
-      facetRequests: null,
       scopedCtsQuery: null,
     },
     expected: false,
   },
   {
-    name: 'no search results and facets requested',
+    name: 'no search results and scopedCtsQuery present',
     input: {
       includeSearchResults: false,
       pageWith: null,
-      facetRequests: [{ name: 'responsibleUnits' }],
       scopedCtsQuery: MOCK_ESTIMATE_QUERY,
     },
     expected: false,
@@ -107,7 +81,6 @@ const scenarios = [
     input: {
       includeSearchResults: false,
       pageWith: 'https://example.com/doc/1',
-      facetRequests: [{ name: 'responsibleUnits' }],
       scopedCtsQuery: null,
     },
     expected: false,

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0821 calculateFacets-semanticFacetCts.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0821 calculateFacets-semanticFacetCts.mjs
@@ -1,0 +1,108 @@
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { executeScenario } from '/test/unitTestUtils.mjs';
+import { calculateFacets } from '/lib/search/engine.mjs';
+import { FacetRequests } from '/lib/search/FacetRequests.mjs';
+import { FACET_ITEM_URI, FACET_SET_URI } from '/test/unitTestConstants.mjs';
+
+const LIB = '0821 calculateFacets-semanticFacetCts.mjs';
+console.log(`${LIB}: starting.`);
+
+let assertions = [];
+
+// Path 1 requires: seed item with member_of.id → seed set classified as collection.
+// The scopedCtsQuery must match the item so cts.estimate counts it.
+const seedItemExists = fn.docAvailable(FACET_ITEM_URI);
+const seedSetExists = fn.docAvailable(FACET_SET_URI);
+
+if (!seedItemExists || !seedSetExists) {
+  assertions.push(
+    testHelperProxy.assertTrue(
+      fn.false(),
+      `${LIB}: seed documents not available (item: ${seedItemExists}, set: ${seedSetExists}); skipping.`,
+    ),
+  );
+} else {
+  // A scopedCtsQuery that matches the seed item document.
+  const scopedCtsQuery = cts.andQuery([
+    cts.jsonPropertyValueQuery('id', FACET_ITEM_URI, ['exact'], 1),
+    cts.fieldValueQuery(
+      'anyDataTypeName',
+      ['HumanMadeObject', 'DigitalObject'],
+      ['exact'],
+    ),
+  ]);
+
+  const scenarios = [
+    {
+      name: 'responsibleCollections via CTS path returns set URI as facet value',
+      input: {
+        facetName: 'responsibleCollections',
+        scopedCtsQuery,
+      },
+      expected: {
+        error: false,
+        totalItems: 1,
+        firstValue: FACET_SET_URI,
+        firstCount: 1,
+      },
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const zeroArityFun = () => {
+      const facetRequests = new FacetRequests(1, 20);
+      facetRequests.addFacetRequest('item', scenario.input.facetName);
+      // Path 1: rows=null, scopedCtsQuery provided → CTS enumerate + estimate.
+      return calculateFacets(
+        null,
+        facetRequests,
+        scenario.input.scopedCtsQuery,
+      );
+    };
+
+    const scenarioResults = executeScenario(scenario, zeroArityFun);
+
+    if (scenarioResults.applyErrorNotExpectedAssertions) {
+      const facetResponses = scenarioResults.actualValue;
+      const facet = facetResponses.getFacet(scenario.input.facetName);
+
+      assertions.push(
+        testHelperProxy.assertEqual(
+          scenario.expected.totalItems,
+          facet.totalItems,
+          `${scenario.name}: totalItems`,
+        ),
+      );
+
+      assertions.push(
+        testHelperProxy.assertTrue(
+          facet.facetValues.length >= 1,
+          `${scenario.name}: expected at least one facet value`,
+        ),
+      );
+
+      assertions.push(
+        testHelperProxy.assertEqual(
+          scenario.expected.firstValue,
+          facet.facetValues[0].value,
+          `${scenario.name}: facet value should be the set URI`,
+        ),
+      );
+
+      assertions.push(
+        testHelperProxy.assertEqual(
+          scenario.expected.firstCount,
+          facet.facetValues[0].count,
+          `${scenario.name}: count`,
+        ),
+      );
+    }
+
+    assertions = assertions.concat(scenarioResults.assertions);
+  }
+}
+
+console.log(`${LIB}: completed ${assertions.length} assertions.`);
+
+assertions;
+export default assertions;

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/1030 HopInverse-ctsFastPath.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/1030 HopInverse-ctsFastPath.mjs
@@ -1,0 +1,221 @@
+/**
+ * Tests HopInverse.apply() Opt 24 CTS fast path.
+ *
+ * When inner criteria resolves to pure CTS (processNestedCriteriaAsCts
+ * returns non-null), HopInverse applies .where(innerCts) directly on
+ * fromTriples instead of building a fromLexicons plan and fragment-joining.
+ *
+ * Does not execute searches against the content database.
+ */
+
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { executeScenario } from '/test/unitTestUtils.mjs';
+import { SearchPatternBase } from '/lib/search/patterns/SearchPatternBase.mjs';
+import { PatternOptions } from '/lib/search/PatternOptions.mjs';
+import '/lib/search/patterns/HopInverse.mjs';
+import op from '/MarkLogic/optic.mjs';
+
+const LIB = '1030 HopInverse-ctsFastPath.mjs';
+console.log(`${LIB}: starting.`);
+
+let assertions = [];
+
+const pattern = SearchPatternBase.get('hopInverse');
+
+const MOCK_PREDICATES = ['la:member_of'];
+const MOCK_TARGET_SCOPE = 'item';
+const MOCK_ID = 'containingItem';
+const MOCK_PARENT_IRI_COL = 'set_iri';
+const MOCK_CRITERIA = {
+  id: 'https://lux.collections.yale.edu/data/object/mock-id',
+};
+const MOCK_CTS_QUERY = cts.documentQuery(MOCK_CRITERIA.id);
+
+function mockSearchTerm() {
+  return {
+    getId: () => MOCK_ID,
+    getParentIriColumn: () => MOCK_PARENT_IRI_COL,
+    getCriteria: () => MOCK_CRITERIA,
+    isTopLevel: () => false,
+    getSearchTermConfig: () => ({
+      getPredicates: () => MOCK_PREDICATES,
+      getTargetScopeName: () => MOCK_TARGET_SCOPE,
+    }),
+  };
+}
+
+function mockPatternOptions() {
+  return new PatternOptions();
+}
+
+// SCP mock where processNestedCriteriaAsCts returns a CTS query (fast path).
+function mockScpWithCts() {
+  return {
+    processNestedCriteriaAsCts: () => MOCK_CTS_QUERY,
+    processNestedCriteria: () => {
+      throw new Error(
+        'processNestedCriteria should not be called on CTS fast path',
+      );
+    },
+  };
+}
+
+// SCP mock where processNestedCriteriaAsCts returns null (fallback path).
+function mockScpFallback() {
+  // processNestedCriteria returns a minimal plan with iri + frag columns.
+  const nestedPlan = op
+    .fromLexicons(
+      { [MOCK_ID + '_iri']: cts.iriReference() },
+      null,
+      op.fragmentIdCol(MOCK_ID + '_frag'),
+    )
+    .select([MOCK_ID + '_iri', MOCK_ID + '_frag']);
+  return {
+    processNestedCriteriaAsCts: () => null,
+    processNestedCriteria: () => nestedPlan,
+  };
+}
+
+const scenarios = [
+  // --- CTS fast path (Opt 24) ---
+  {
+    name: 'CTS fast path: plan uses fromTriples with .where(), no fromLexicons',
+    input: { scp: mockScpWithCts() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      planContains: ['fromTriples', 'member_of', 'documentQuery'],
+      planExcludes: ['fromLexicons'],
+    },
+  },
+  {
+    name: 'CTS fast path: no fragment join columns in the plan',
+    input: { scp: mockScpWithCts() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      // Fragment join uses on(triFrag, refFrag) — with CTS fast path,
+      // neither column name pattern should appear in a join context.
+      planExcludes: ['fromLexicons', MOCK_ID + '_frag'],
+    },
+  },
+  {
+    name: 'CTS fast path: outer join key uses parent IRI and triple object',
+    input: { scp: mockScpWithCts() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      joinOnContains: [MOCK_PARENT_IRI_COL, MOCK_ID + '_o'],
+    },
+  },
+
+  // --- Fallback path (processNestedCriteriaAsCts returns null) ---
+  {
+    name: 'Fallback: plan uses fromTriples joined to fromLexicons via fragment',
+    input: { scp: mockScpFallback() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      planContains: ['fromTriples', 'fromLexicons', 'member_of'],
+      planExcludes: ['documentQuery'],
+    },
+  },
+  {
+    name: 'Fallback: plan includes fragment join columns',
+    input: { scp: mockScpFallback() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      planContains: [MOCK_ID + '_triFrag', MOCK_ID + '_frag'],
+    },
+  },
+  {
+    name: 'Fallback: outer join key unchanged from CTS path',
+    input: { scp: mockScpFallback() },
+    expected: {
+      error: false,
+      hasPatternJoins: true,
+      joinOnContains: [MOCK_PARENT_IRI_COL, MOCK_ID + '_o'],
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  const zeroArityFun = () => {
+    return pattern.apply(
+      scenario.input.scp,
+      mockSearchTerm(),
+      'and',
+      mockPatternOptions(),
+    );
+  };
+
+  const scenarioResults = executeScenario(scenario, zeroArityFun);
+
+  if (scenarioResults.applyErrorNotExpectedAssertions) {
+    const result = scenarioResults.actualValue;
+    const e = scenario.expected;
+    const p = scenario.name;
+
+    if (e.hasPatternJoins) {
+      assertions.push(
+        testHelperProxy.assertTrue(
+          result &&
+            Array.isArray(result.patternJoins) &&
+            result.patternJoins.length > 0,
+          `${p}: should return patternJoins`,
+        ),
+      );
+    }
+
+    if (result && result.patternJoins && result.patternJoins.length > 0) {
+      const pj = result.patternJoins[0];
+      const planSource = op.toSource(pj.right.export());
+
+      if (e.planContains) {
+        for (const text of e.planContains) {
+          assertions.push(
+            testHelperProxy.assertTrue(
+              typeof planSource === 'string' && planSource.includes(text),
+              `${p}: plan should contain '${text}'`,
+            ),
+          );
+        }
+      }
+
+      if (e.planExcludes) {
+        for (const text of e.planExcludes) {
+          assertions.push(
+            testHelperProxy.assertFalse(
+              typeof planSource === 'string' && planSource.includes(text),
+              `${p}: plan should NOT contain '${text}'`,
+            ),
+          );
+        }
+      }
+
+      if (e.joinOnContains) {
+        const joinOnSource = JSON.stringify(pj.on);
+        for (const text of e.joinOnContains) {
+          assertions.push(
+            testHelperProxy.assertTrue(
+              typeof joinOnSource === 'string' && joinOnSource.includes(text),
+              `${p}: join on should contain '${text}'`,
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  if (scenarioResults.assertions.length > 0) {
+    assertions = assertions.concat(scenarioResults.assertions);
+  }
+}
+
+console.log(
+  `${LIB}: completed ${assertions.length} assertions from ${scenarios.length} scenarios.`,
+);
+
+assertions;
+export default assertions;

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/test-data/facetItem.json
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/test-data/facetItem.json
@@ -1,7 +1,12 @@
 {
   "json": {
     "id": "https://lux.collections.yale.edu/data/object/test-facet-item",
-    "type": "HumanMadeObject"
+    "type": "HumanMadeObject",
+    "member_of": [
+      {
+        "id": "https://lux.collections.yale.edu/data/set/test-facet-set"
+      }
+    ]
   },
   "indexedProperties": {
     "dataType": "HumanMadeObject"

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/test-data/facetSet.json
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/test-data/facetSet.json
@@ -1,7 +1,16 @@
 {
   "json": {
     "id": "https://lux.collections.yale.edu/data/set/test-facet-set",
-    "type": "Set"
+    "type": "Set",
+    "classified_as": [
+      {
+        "equivalent": [
+          {
+            "id": "http://vocab.getty.edu/aat/300025976"
+          }
+        ]
+      }
+    ]
   },
   "indexedProperties": {
     "dataType": "Set"


### PR DESCRIPTION
PR includes:

1. Opt 21: facet optimization, described in more detail below.
2. Facet value count fix.  Didn't check to see if this was an issue in the optic-refactor branch.
3. Opt 24: HopInverse optimization (via PR #704)
4. Unit test assertion count up to 1,870

---

Primary drawbacks of this optimization are a) having CTS and Optic definitions for each semantic facet, and b) three-way conditional logic in `performSearch` and `calculateFacets`.  However, the performance gain is hard to argue with.

Most relevant excerpt from lux-optic-primer.md:

### Implementation

The implementation spans three layers: execution strategy in `performSearch`, facet dispatch in `calculateFacets`, and per-facet CTS configuration in `semanticFacetsConfig.mjs`.

#### `performSearch` execution paths ([engine.mjs](/src/main/ml-modules/root/lib/search/engine.mjs))

Three branches in `performSearch` determine how rows are produced, then a single `calculateFacets` call handles all facet computation:

1. **CTS-eligible (`ctsExecutionEligible`):** Search results are requested, the accumulator is join-free, and `scopedCtsQuery` is non-null. Page results use `cts.estimate` (total) + `offset/limit` (page slice) via Opt 18/20. `rows` stays `null` — no full materialization.

5. **Facet-only with CTS (`!includeSearchResults && scopedCtsQuery`):** Facets were requested without search results and the query is CTS-foldable. `rows` stays `null`. No plan execution at all — `calculateFacets` works directly from `scopedCtsQuery`.

6. **Full materialization (else):** The query has joins (hops, annTopK) or other conditions that prevent CTS execution. All matching rows are materialized. Search results are paginated from the array if requested. `rows` is passed to `calculateFacets` for URI extraction.

After the branch, one call:

```javascript
facetResponses = calculateFacets(rows, facetRequests, scopedCtsQuery);
```

`isCtsExecutionEligible` no longer checks for facet requests — Opt 21 made facets compatible with the CTS execution path. This means Opt 18/20 now fire even when facets are co-requested with search results, avoiding full materialization entirely for join-free queries.

#### `calculateFacets` dispatch ([calculateFacets.mjs](/src/main/ml-modules/root/lib/search/calculateFacets.mjs))

Three paths per facet, gated by `scopedCtsQuery` and facet type:

- **Path 1 — CTS semantic** (`isSemanticFacet && scopedCtsQuery`): Enumerate candidates via `cts.search(potentialFacetValuesCtsQuery)`, count each via `cts.estimate(getValuesCountCtsQuery(scopedCtsQuery, uri))`, filter count > 0, sort by count desc. No Optic plan. Capped at `SEMANTIC_VALUE_LIMIT` (100) — both current semantic facets (`responsibleCollections`: ~66 values, `responsibleUnits`: fewer) are well within this limit.

- **Path 2 — Optic with CTS query** (`!isSemanticFacet && scopedCtsQuery`): `op.fromSearch(scopedCtsQuery)` replaces the old `cts.documentQuery(uriList)`. The downstream Optic chain (`joinInner(fromLexicons) → groupBy → orderBy`) is unchanged.

- **Path 3 — Optic with URI list** (no `scopedCtsQuery`): Fallback for non-foldable queries. `rows.map(r => r.id)` extracts URIs, `op.fromSearch(cts.documentQuery(uriList))` builds the document set. This is the pre-Opt-21 behavior, used when the query involves `hopInverse`, transitive `hopWithField`, or `annTopK`.

**Why not a uniform Optic path?** Optic works well for non-semantic facets (Path 2: 125ms) because the plan is simple. For semantic facets, the plan grows to 4-5 joins with `fromTriples`/`fromSPARQL`, and the optimizer cannot efficiently process it at 2.5M scale (210-340s). Even denormalized field indexes (1,574ms) are 4.8× slower than CTS.

**Why not a uniform CTS path?** CTS `cts.fieldValues` could replace Path 2, but Optic is already fast (125ms) and preserves the existing pagination, sort-order, and date-facet handling. The marginal gain doesn't justify the code duplication.
