### PR TITLE
Search term options and weights

### DIFF
--- a/src/main/ml-modules/root/lib/search/SearchTerm.mjs
+++ b/src/main/ml-modules/root/lib/search/SearchTerm.mjs
@@ -344,7 +344,8 @@ const SearchTerm = class {
     return this;
   }
   setWeight(weight) {
-    this.props.weight = weight;
+    // MarkLogic uses -16 through 64.
+    this.props.weight = Number.isFinite(Number(weight)) ? Number(weight) : 1;
   }
   getWeight() {
     return this.props.weight ?? 1;

--- a/src/main/ml-modules/root/lib/search/SearchTerm.mjs
+++ b/src/main/ml-modules/root/lib/search/SearchTerm.mjs
@@ -347,7 +347,7 @@ const SearchTerm = class {
     this.props.weight = weight;
   }
   getWeight() {
-    return this.props.weight;
+    return this.props.weight ?? 1;
   }
   hasNumericWeight() {
     return !isNaN(this.props.weight);

--- a/src/main/ml-modules/root/lib/search/patterns/DateRange.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/DateRange.mjs
@@ -75,6 +75,8 @@ class DateRange extends SearchPatternBase {
     // Operator = tests both (overlap). Operator != uses OR of two ranges.
     const ctsConstraints = [];
 
+    const termSearchOptions = []; // Electing not to use searchTerm's options.
+    const termWeight = searchTerm.getWeight();
     if (['>', '>=', '<', '<='].includes(operator)) {
       // All single-sided operators test the document's start date (qS).
       // Use the start of the search date for >= and <; the end of the search date for > and <=.
@@ -82,24 +84,54 @@ class DateRange extends SearchPatternBase {
         ? startDateLong
         : endDateLong;
       ctsConstraints.push(
-        cts.fieldRangeQuery(startIndexName, operator, dateLong),
+        cts.fieldRangeQuery(
+          startIndexName,
+          operator,
+          dateLong,
+          termSearchOptions,
+          termWeight,
+        ),
       );
     } else if (operator === '=') {
       // Overlap: a document qualifies if its timespan [qS, qE] overlaps the search range [aS, aE].
       // Condition: qS <= aE AND qE >= aS
       ctsConstraints.push(
-        cts.fieldRangeQuery(startIndexName, '<=', endDateLong),
+        cts.fieldRangeQuery(
+          startIndexName,
+          '<=',
+          endDateLong,
+          termSearchOptions,
+          termWeight,
+        ),
       );
       ctsConstraints.push(
-        cts.fieldRangeQuery(endIndexName, '>=', startDateLong),
+        cts.fieldRangeQuery(
+          endIndexName,
+          '>=',
+          startDateLong,
+          termSearchOptions,
+          termWeight,
+        ),
       );
     } else if (operator === '!=') {
       // Complement of overlap: a document qualifies if its timespan does NOT overlap [aS, aE].
       // Condition: qS > aE OR qE < aS
       ctsConstraints.push(
         cts.orQuery([
-          cts.fieldRangeQuery(startIndexName, '>', endDateLong),
-          cts.fieldRangeQuery(endIndexName, '<', startDateLong),
+          cts.fieldRangeQuery(
+            startIndexName,
+            '>',
+            endDateLong,
+            termSearchOptions,
+            termWeight,
+          ),
+          cts.fieldRangeQuery(
+            endIndexName,
+            '<',
+            startDateLong,
+            termSearchOptions,
+            termWeight,
+          ),
         ]),
       );
     } else {

--- a/src/main/ml-modules/root/lib/search/patterns/Geospatial.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/Geospatial.mjs
@@ -63,7 +63,15 @@ class Geospatial extends SearchPatternBase {
       REGION_INVALID_VALUES,
     );
     return {
-      ctsConstraints: [cts.geospatialRegionQuery(ref, operator, region)],
+      ctsConstraints: [
+        cts.geospatialRegionQuery(
+          ref,
+          operator,
+          region,
+          [], // Electing not to use searchTerm's options
+          searchTerm.getWeight(),
+        ),
+      ],
     };
   }
 
@@ -74,7 +82,12 @@ class Geospatial extends SearchPatternBase {
     const path = this.#getIndexReference(searchTerm);
     return {
       ctsConstraints: [
-        cts.pathGeospatialQuery(path, region, POINT_INDEX_OPTIONS),
+        cts.pathGeospatialQuery(
+          path,
+          region,
+          POINT_INDEX_OPTIONS, // Electing not to include searchTerm's options
+          searchTerm.getWeight(),
+        ),
       ],
     };
   }

--- a/src/main/ml-modules/root/lib/search/patterns/HopInverse.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/HopInverse.mjs
@@ -117,13 +117,12 @@ class HopInverse extends SearchPatternBase {
       termConfig.getTargetScopeName(),
       false,
     );
+    // Using default options and weight for values-only request.
     const childQuery = cts.tripleRangeQuery(
       [],
       childPredicates,
       targetIRI,
       '=',
-      [],
-      1.0,
     );
     const fragmentConstraint =
       targetScopeTypes.length > 0

--- a/src/main/ml-modules/root/lib/search/patterns/HopWithField.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/HopWithField.mjs
@@ -74,6 +74,8 @@ select ?${id}_s ?${id}_o where {
     const hopIriCol = searchTerm.getParentIriColumn();
     const fieldIriCol = searchTerm.getIriColumn();
     const hopFragCol = searchTerm.getParentFragmentColumn();
+    const termSearchOptions = []; // only use search options in fieldWordQuery.
+    const termWeight = searchTerm.getWeight();
     const hopTripleFragCol = id + '_hopFrag';
 
     // When criteria is a direct IRI ({ iri: value } or { id: value }) and no
@@ -97,8 +99,8 @@ select ?${id}_s ?${id}_o where {
               sem.iri('/does/not/exist'),
             ),
             '=',
-            [],
-            1,
+            termSearchOptions,
+            termWeight,
           ),
         ],
       };
@@ -131,8 +133,8 @@ select ?${id}_s ?${id}_o where {
                 sem.iri('/does/not/exist'),
               ),
               '=',
-              [],
-              1,
+              termSearchOptions,
+              termWeight,
             ),
           ],
         };
@@ -212,6 +214,7 @@ select ?${id}_s ?${id}_o where {
     const id = searchTerm.getId();
     const termValue = searchTerm.getValue();
     const termSearchOptions = searchTerm.getSearchOptions();
+    const termWeight = searchTerm.getWeight();
     const termConfig = searchTerm.getSearchTermConfig();
     const fieldIriCol = searchTerm.getIriColumn();
     const indexReferences = termConfig.getIndexReferences();
@@ -229,7 +232,12 @@ select ?${id}_s ?${id}_o where {
             [fieldIriCol]: cts.iriReference(),
           })
           .where(
-            cts.fieldWordQuery(indexReferences, termValue, termSearchOptions),
+            cts.fieldWordQuery(
+              indexReferences,
+              termValue,
+              termSearchOptions,
+              termWeight,
+            ),
           );
   }
 

--- a/src/main/ml-modules/root/lib/search/patterns/IndexedRange.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/IndexedRange.mjs
@@ -7,6 +7,8 @@ class IndexedRange extends SearchPatternBase {
     const termValue = searchTerm.getValue();
     const termConfig = searchTerm.getSearchTermConfig();
     const operator = searchTerm.getComparisonOperator();
+    const termSearchOptions = []; // Electing not to use searchTerm's options.
+    const termWeight = searchTerm.getWeight();
 
     this.requireRangeOperator(searchTerm.getName(), operator);
 
@@ -16,6 +18,8 @@ class IndexedRange extends SearchPatternBase {
           termConfig.getIndexReferences(),
           operator,
           termValue,
+          termSearchOptions,
+          termWeight,
         ),
       ],
     };

--- a/src/main/ml-modules/root/lib/search/patterns/IndexedValue.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/IndexedValue.mjs
@@ -6,6 +6,7 @@ class IndexedValue extends SearchPatternBase {
     const termValue = searchTerm.getValue();
     const termConfig = searchTerm.getSearchTermConfig();
     const termSearchOptions = searchTerm.getSearchOptions();
+    const termWeight = searchTerm.getWeight();
 
     // CTS constraint rather than op.eq on a range lexicon: simple column value
     // comparisons do not support wildcarding, stemming, or sensitivity options
@@ -21,6 +22,7 @@ class IndexedValue extends SearchPatternBase {
           termConfig.getIndexReferences(),
           termValue,
           termSearchOptions,
+          termWeight,
         ),
       ],
     };

--- a/src/main/ml-modules/root/lib/search/patterns/IndexedWord.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/IndexedWord.mjs
@@ -6,6 +6,7 @@ class IndexedWord extends SearchPatternBase {
     const termValue = searchTerm.getValue();
     const termConfig = searchTerm.getSearchTermConfig();
     const termSearchOptions = searchTerm.getSearchOptions();
+    const termWeight = searchTerm.getWeight();
 
     // CTS constraint for same reason as indexedValue pattern.
     return {
@@ -15,11 +16,13 @@ class IndexedWord extends SearchPatternBase {
               termConfig.getIndexReferences(),
               termValue,
               termSearchOptions,
+              termWeight,
             )
           : cts.fieldWordQuery(
               termConfig.getIndexReferences(),
               termValue,
               termSearchOptions,
+              termWeight,
             ),
       ],
     };

--- a/src/main/ml-modules/root/lib/search/patterns/Keyword.mjs
+++ b/src/main/ml-modules/root/lib/search/patterns/Keyword.mjs
@@ -17,7 +17,7 @@ class Keyword extends SearchPatternBase {
       termValues: utils.toArray(searchTerm.getValue()),
       termScopeName: searchTerm.getScopeName(),
       isCompleteMatch: searchTerm.isCompleteMatch(),
-      searchOptions: searchTerm.getSearchOptions(),
+      termSearchOptions: searchTerm.getSearchOptions(),
       termWeight: searchTerm.getWeight() ?? 1.0,
     });
     return { ctsConstraints: [ctsQuery] };
@@ -56,21 +56,21 @@ function buildKeywordCtsQuery({
   termValues,
   termScopeName,
   isCompleteMatch = false,
-  searchOptions,
+  termSearchOptions,
   termWeight = 1.0,
 }) {
   const nonSemanticWordQuery = buildWordQueries(
     getSearchScopeFields(termScopeName),
     termValues,
     isCompleteMatch,
-    searchOptions,
+    termSearchOptions,
     termWeight,
   );
   const semanticWordQuery = buildWordQueries(
     [FULL_TEXT_SEARCH_RELATED_FIELD_NAME],
     termValues,
     isCompleteMatch,
-    searchOptions,
+    termSearchOptions,
     termWeight,
   );
   const refIris = cts
@@ -90,7 +90,7 @@ function buildKeywordCtsQuery({
     expandPredicates(getSearchScopePredicates(termScopeName)),
     refIris,
     '=',
-    [],
+    [], // do not use keyword's search options here (e.g., case-sensitive)
     termWeight,
   );
 
@@ -100,9 +100,17 @@ function buildKeywordCtsQuery({
 // Builds a single CTS field query, or an AND of them when multiple values
 // are supplied. fieldWordQuery / fieldValueQuery accept an array of field
 // names natively, so multiple fields are passed through as-is.
-function buildWordQueries(fields, values, isCompleteMatch, options, weight) {
+function buildWordQueries(
+  fields,
+  values,
+  isCompleteMatch,
+  termSearchOptions,
+  termWeight,
+) {
   const queryFn = isCompleteMatch ? cts.fieldValueQuery : cts.fieldWordQuery;
-  const queries = values.map((v) => queryFn(fields, v, options, weight));
+  const queries = values.map((v) =>
+    queryFn(fields, v, termSearchOptions, termWeight),
+  );
   return queries.length === 1 ? queries[0] : cts.andQuery(queries);
 }
 

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/1000 DateRange-comparator.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/1000 DateRange-comparator.mjs
@@ -28,6 +28,7 @@ function mockSearchTerm(operator, value = '1800;1900') {
         'agentBornEndDateLong',
       ],
     }),
+    getWeight: () => 2,
   };
 }
 

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/1020 IndexedRange-comparator.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/1020 IndexedRange-comparator.mjs
@@ -23,6 +23,7 @@ function mockSearchTerm(operator) {
     getSearchTermConfig: () => ({
       getIndexReferences: () => ['itemDepthDimensionValue'],
     }),
+    getWeight: () => 5,
   };
 }
 


### PR DESCRIPTION
Reviewed all search patterns' uses of search term options and weights.  All now use weights.  Search options are selectively used.  Examples:

* We don't utilize cts.fieldRangeQuery's options so better to not pass on whatever may be on the search term.
* Patterns that have cts.tripleRangeQuery and cts.field*Query should only use the options on the latter.