### PR TITLE
Do not calculate scores when only asked to sort by a lexicon(s)

### DIFF
--- a/src/main/ml-modules/root/lib/SortCriteria.mjs
+++ b/src/main/ml-modules/root/lib/SortCriteria.mjs
@@ -126,7 +126,7 @@ const SortCriteria = class {
       return true;
     }, this);
 
-    // Do not calculate scores when we're only to support by a lexicon(s).
+    // Do not calculate scores when we're only asked to sort by one or more lexicons.
     if (!hasExplicitRelevance && this.#nonSemanticSortDescriptors.length > 0) {
       this.#relevanceSort = false;
     }

--- a/src/main/ml-modules/root/lib/SortCriteria.mjs
+++ b/src/main/ml-modules/root/lib/SortCriteria.mjs
@@ -70,6 +70,7 @@ const SortCriteria = class {
   #parse() {
     let sortByName = '';
     let specifiedOrder = '';
+    let hasExplicitRelevance = false;
     const sortList = utils.split(this.#sortCriteriaStr);
     sortList.every(function (item) {
       if (item != '') {
@@ -84,6 +85,7 @@ const SortCriteria = class {
         // exclude 'random' and semantic sort given their return statements.
         else if (sortByName?.toLowerCase() == 'relevance') {
           this.#relevanceSort = true;
+          hasExplicitRelevance = true;
         } else {
           const sortBinding = SORT_BINDINGS[sortByName];
           // Protect from sorting by a different scope's binding.
@@ -123,6 +125,11 @@ const SortCriteria = class {
       }
       return true;
     }, this);
+
+    // Do not calculate scores when we're only to support by a lexicon(s).
+    if (!hasExplicitRelevance && this.#nonSemanticSortDescriptors.length > 0) {
+      this.#relevanceSort = false;
+    }
   }
 
   #getOrder(specifiedOrder, bindingOrder = null) {

--- a/src/test/ml-modules/root/test/suites/classTests/0200 SortCriteria.mjs
+++ b/src/test/ml-modules/root/test/suites/classTests/0200 SortCriteria.mjs
@@ -142,9 +142,9 @@ const scenarios = [
     input: { scopeName: 'agent', sortCriteriaStr: 'agentActiveDate' },
     expected: {
       error: false,
-      isRelevanceSort: true,
+      isRelevanceSort: false,
       isRandomSort: false,
-      areScoresRequired: true,
+      areScoresRequired: false,
       hasNonSemanticSortDescriptors: true,
       getNonSemanticSortDescriptors: [
         { indexReference: 'agentActiveStartDateLong', order: 'ascending' },
@@ -158,9 +158,9 @@ const scenarios = [
     input: { scopeName: 'agent', sortCriteriaStr: 'agentActiveDate:desc' },
     expected: {
       error: false,
-      isRelevanceSort: true,
+      isRelevanceSort: false,
       isRandomSort: false,
-      areScoresRequired: true,
+      areScoresRequired: false,
       hasNonSemanticSortDescriptors: true,
       getNonSemanticSortDescriptors: [
         { indexReference: 'agentActiveStartDateLong', order: 'descending' },
@@ -174,9 +174,9 @@ const scenarios = [
     input: { scopeName: 'agent', sortCriteriaStr: 'agentHasDigitalImage' },
     expected: {
       error: false,
-      isRelevanceSort: true,
+      isRelevanceSort: false,
       isRandomSort: false,
-      areScoresRequired: true,
+      areScoresRequired: false,
       hasNonSemanticSortDescriptors: true,
       getNonSemanticSortDescriptors: [
         { indexReference: 'agentHasDigitalImageBoolean', order: 'descending' },
@@ -193,9 +193,9 @@ const scenarios = [
     },
     expected: {
       error: false,
-      isRelevanceSort: true,
+      isRelevanceSort: false,
       isRandomSort: false,
-      areScoresRequired: true,
+      areScoresRequired: false,
       hasNonSemanticSortDescriptors: true,
       getNonSemanticSortDescriptors: [
         { indexReference: 'agentActiveStartDateLong', order: 'ascending' },
@@ -252,7 +252,7 @@ const scenarios = [
 
   // --- Mixed relevance + non-semantic ---
   {
-    name: 'Relevance combined with non-semantic — both active, scores required',
+    name: 'Relevance then non-semantic — both active, scores required',
     input: {
       scopeName: 'agent',
       sortCriteriaStr: 'relevance,agentActiveDate',
@@ -270,7 +270,25 @@ const scenarios = [
       getSemanticSortOption: null,
     },
   },
-
+  {
+    name: 'Non-semantic then relevance — both active, scores required',
+    input: {
+      scopeName: 'agent',
+      sortCriteriaStr: 'agentActiveDate,relevance',
+    },
+    expected: {
+      error: false,
+      isRelevanceSort: true,
+      isRandomSort: false,
+      areScoresRequired: true,
+      hasNonSemanticSortDescriptors: true,
+      getNonSemanticSortDescriptors: [
+        { indexReference: 'agentActiveStartDateLong', order: 'ascending' },
+      ],
+      hasSemanticSortOption: false,
+      getSemanticSortOption: null,
+    },
+  },
   // --- Invalid / ignored bindings ---
   {
     name: 'Wrong scope binding is ignored — defaults to relevance',

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0405 buildPlans-buildSortedResultsPlan.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0405 buildPlans-buildSortedResultsPlan.mjs
@@ -56,7 +56,8 @@ const scenarios = [
     },
     expected: {
       error: false,
-      sortedPlanContains: ['fromSearch', 'score'],
+      orderByContains: ['score'],
+      sortedPlanContains: ['fromSearch'],
       sortedPlanExcludes: ['randomSortCol', 'fromTriples'],
     },
   },
@@ -69,7 +70,8 @@ const scenarios = [
     },
     expected: {
       error: false,
-      sortedPlanContains: ['fromSearch', 'score'],
+      orderByContains: ['score'],
+      sortedPlanContains: ['fromSearch'],
       sortedPlanExcludes: ['randomSortCol', 'fromTriples'],
     },
   },
@@ -166,7 +168,7 @@ const scenarios = [
     },
   },
   {
-    name: 'Non-semantic sort adds sort lexicon column alongside fromSearch',
+    name: 'Non-semantic sort adds sort lexicon column',
     input: {
       scopeName: 'agent',
       searchCriteria: TEXT_CRITERIA,
@@ -174,8 +176,7 @@ const scenarios = [
     },
     expected: {
       error: false,
-      // Non-semantic sort coexists with fromSearch (relevance is still true).
-      sortedPlanContains: ['agentActiveStartDateLong', 'fromSearch'],
+      orderByContains: ['agentActiveStartDateLong'],
       sortedPlanExcludes: ['randomSortCol', 'fromTriples'],
     },
   },
@@ -188,7 +189,7 @@ const scenarios = [
     },
     expected: {
       error: false,
-      sortedPlanContains: ['agentActiveStartDateLong'],
+      orderByContains: ['agentActiveStartDateLong'],
       sortedPlanExcludes: ['randomSortCol', 'fromTriples', 'fromSearch'],
     },
   },
@@ -235,7 +236,7 @@ const scenarios = [
     },
     expected: {
       error: false,
-      sortedPlanContains: ['agentActiveStartDateLong', 'desc'],
+      orderByContains: ['agentActiveStartDateLong', 'desc'],
     },
   },
   {
@@ -247,10 +248,7 @@ const scenarios = [
     },
     expected: {
       error: false,
-      sortedPlanContains: [
-        'agentActiveStartDateLong',
-        'agentDiedStartDateLong',
-      ],
+      orderByContains: ['agentActiveStartDateLong', 'agentDiedStartDateLong'],
     },
   },
   {
@@ -383,7 +381,8 @@ const scenarios = [
     expected: {
       error: false,
       // keyword contributes score → hasScoreContributingCriteria is true
-      sortedPlanContains: ['fromSearch', 'score'],
+      orderByContains: ['score'],
+      sortedPlanContains: ['fromSearch'],
     },
   },
   {
@@ -395,7 +394,8 @@ const scenarios = [
     },
     expected: {
       error: false,
-      sortedPlanContains: ['fromSearch', 'score', 'agentName'],
+      orderByContains: ['score'],
+      sortedPlanContains: ['fromSearch', 'agentName'],
     },
   },
   {
@@ -413,7 +413,8 @@ const scenarios = [
     },
     expected: {
       error: false,
-      sortedPlanContains: ['fromSearch', 'score'],
+      orderByContains: ['score'],
+      sortedPlanContains: ['fromSearch'],
     },
   },
   {

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0406 buildPlans-unsortedResultsPlan.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0406 buildPlans-unsortedResultsPlan.mjs
@@ -54,20 +54,8 @@ const scenarios = [
     consistencyGroup: 'A',
   },
   {
-    name: 'Single non-semantic sort',
-    input: { sortDelimitedStr: 'agentActiveDate' },
-    expected: { error: false },
-    consistencyGroup: 'A',
-  },
-  {
-    name: 'Multiple non-semantic sorts',
-    input: { sortDelimitedStr: 'agentActiveDate,agentEndDate' },
-    expected: { error: false },
-    consistencyGroup: 'A',
-  },
-  {
-    name: 'Non-semantic descending',
-    input: { sortDelimitedStr: 'agentActiveDate:desc' },
+    name: 'Explicit relevance and non-semantic',
+    input: { sortDelimitedStr: 'relevance,agentActiveDate' },
     expected: { error: false },
     consistencyGroup: 'A',
   },
@@ -96,6 +84,24 @@ const scenarios = [
     input: {
       sortDelimitedStr: 'agentActiveDate,agentClassificationConceptName',
     },
+    expected: { error: false },
+    consistencyGroup: 'B',
+  },
+  {
+    name: 'Single non-semantic sort',
+    input: { sortDelimitedStr: 'agentActiveDate' },
+    expected: { error: false },
+    consistencyGroup: 'B',
+  },
+  {
+    name: 'Multiple non-semantic sorts',
+    input: { sortDelimitedStr: 'agentActiveDate,agentEndDate' },
+    expected: { error: false },
+    consistencyGroup: 'B',
+  },
+  {
+    name: 'Non-semantic descending',
+    input: { sortDelimitedStr: 'agentActiveDate:desc' },
     expected: { error: false },
     consistencyGroup: 'B',
   },

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0901 processNestedCriteria-selectBarrier.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0901 processNestedCriteria-selectBarrier.mjs
@@ -129,25 +129,10 @@ for (const scenario of scenarios) {
     const e = scenario.expected;
     const name = scenario.name;
 
-    // Extract all .select([...]) argument lists from the serialized plan.
     const selectArgs =
       typeof planSource === 'string'
         ? [...planSource.matchAll(/\.select\(\[([^\]]+)\]\)/g)].map((m) => m[1])
         : [];
-
-    if (e.selectContains) {
-      for (const col of e.selectContains) {
-        const found = selectArgs.some((args) =>
-          new RegExp(`'[^']*${col}'`).test(args),
-        );
-        assertions.push(
-          testHelperProxy.assertTrue(
-            found,
-            `${name}: a .select() should contain a column matching '${col}'`,
-          ),
-        );
-      }
-    }
 
     if (e.selectExcludes) {
       for (const col of e.selectExcludes) {

--- a/src/test/ml-modules/root/test/unitTestUtils.mjs
+++ b/src/test/ml-modules/root/test/unitTestUtils.mjs
@@ -122,6 +122,9 @@ function executeScenario(scenario, zeroArityFun, invokeFunOptions = {}) {
         }
       });
     }
+
+    applyOpticCallContainsAssertions('select', 'selectContains');
+    applyOpticCallContainsAssertions('orderBy', 'orderByContains');
   }
 
   return {
@@ -129,6 +132,33 @@ function executeScenario(scenario, zeroArityFun, invokeFunOptions = {}) {
     applyErrorNotExpectedAssertions,
     assertions,
   };
+}
+
+function applyOpticCallContainsAssertions(opticFunName, expectedKey) {
+  if (
+    typeof actualValue !== 'string' ||
+    !isArray(scenario.expected[expectedKey])
+  ) {
+    return;
+  }
+
+  const callArgs = [
+    ...actualValue.matchAll(
+      new RegExp(`\\.${opticFunName}\\(\\[([^\\]]+)\\]\\)`, 'g'),
+    ),
+  ].map((m) => m[1]);
+
+  scenario.expected[expectedKey].forEach((col) => {
+    const found = callArgs.some((args) =>
+      new RegExp(`'[^']*${col}'`).test(args),
+    );
+    assertions.push(
+      testHelperProxy.assertTrue(
+        found,
+        `Scenario '${scenario.name}': .${opticFunName}() should contain a column matching '${col}'`,
+      ),
+    );
+  });
 }
 
 function loadTestFile(uri, filename, collections = []) {

--- a/src/test/ml-modules/root/test/unitTestUtils.mjs
+++ b/src/test/ml-modules/root/test/unitTestUtils.mjs
@@ -123,6 +123,31 @@ function executeScenario(scenario, zeroArityFun, invokeFunOptions = {}) {
       });
     }
 
+    const applyOpticCallContainsAssertions = (opticFunName, expectedKey) => {
+      if (
+        typeof actualValue !== 'string' ||
+        !isArray(scenario.expected[expectedKey])
+      ) {
+        return;
+      }
+
+      const callArgs = [
+        ...actualValue.matchAll(
+          new RegExp(`\\.${opticFunName}\\(\\[([^\\]]+)\\]\\)`, 'g'),
+        ),
+      ].map((m) => m[1]);
+
+      scenario.expected[expectedKey].forEach((col) => {
+        const found = callArgs.some((args) => args.includes(col));
+        assertions.push(
+          testHelperProxy.assertTrue(
+            found,
+            `Scenario '${scenario.name}': .${opticFunName}() should contain a column matching '${col}'`,
+          ),
+        );
+      });
+    };
+
     applyOpticCallContainsAssertions('select', 'selectContains');
     applyOpticCallContainsAssertions('orderBy', 'orderByContains');
   }
@@ -132,33 +157,6 @@ function executeScenario(scenario, zeroArityFun, invokeFunOptions = {}) {
     applyErrorNotExpectedAssertions,
     assertions,
   };
-}
-
-function applyOpticCallContainsAssertions(opticFunName, expectedKey) {
-  if (
-    typeof actualValue !== 'string' ||
-    !isArray(scenario.expected[expectedKey])
-  ) {
-    return;
-  }
-
-  const callArgs = [
-    ...actualValue.matchAll(
-      new RegExp(`\\.${opticFunName}\\(\\[([^\\]]+)\\]\\)`, 'g'),
-    ),
-  ].map((m) => m[1]);
-
-  scenario.expected[expectedKey].forEach((col) => {
-    const found = callArgs.some((args) =>
-      new RegExp(`'[^']*${col}'`).test(args),
-    );
-    assertions.push(
-      testHelperProxy.assertTrue(
-        found,
-        `Scenario '${scenario.name}': .${opticFunName}() should contain a column matching '${col}'`,
-      ),
-    );
-  });
 }
 
 function loadTestFile(uri, filename, collections = []) {


### PR DESCRIPTION
SortCriteria now turns relevance scores off when only to sort by lexicons.

Refactored selectContains out of unit test module 905 and into executeScenario.  Made it generic to also support orderByContains, which is now being used in 405.