### PR TITLE
Bail sooner when estimate is zero

### DIFF
--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -30,7 +30,12 @@ const SEMANTIC_VALUE_LIMIT = 100;
 // When scopedCtsQuery is null (non-foldable query):
 //   - All facets use op.fromSearch(cts.documentQuery(uriList)) (Path 3).
 //   - rows must be non-null.
-function calculateFacets(rows, facetRequests, scopedCtsQuery = null) {
+function calculateFacets(
+  rows,
+  facetRequests,
+  scopedCtsQuery = null,
+  scopedCtsQueryEstimate = null,
+) {
   if (facetRequests == null || facetRequests.length === 0) {
     return null;
   }
@@ -38,6 +43,13 @@ function calculateFacets(rows, facetRequests, scopedCtsQuery = null) {
   const requests = facetRequests.getFacetRequests();
   if (!utils.isNonEmptyArray(requests)) {
     return new FacetResponses({});
+  }
+
+  // Use the estimate when provided, but do not call cts.estimate here when
+  // absent; forcing an estimate in this layer can impose a performance
+  // penalty for some query shapes.
+  if (scopedCtsQuery && scopedCtsQueryEstimate === 0) {
+    return _buildEmptyFacetResponses(requests);
   }
 
   // Path 3 setup: extract URIs from materialized rows.

--- a/src/main/ml-modules/root/lib/search/engine.mjs
+++ b/src/main/ml-modules/root/lib/search/engine.mjs
@@ -99,13 +99,17 @@ function performSearch(scp) {
       planAsSource = getPlanSource(planAsJson);
 
       let rows = null;
+      let scopedCtsQueryEstimate = null;
       if (ctsExecutionEligible) {
         const effectivePageLength = pageLength ?? 20;
-        total = cts.estimate(scopedCtsQuery);
+        scopedCtsQueryEstimate = cts.estimate(scopedCtsQuery);
+        total = scopedCtsQueryEstimate;
         resultPage = Math.max(page, 1);
         const offset = (resultPage - 1) * effectivePageLength;
 
-        if (isFromSearchPlan) {
+        if (total === 0) {
+          searchResults = [];
+        } else if (isFromSearchPlan) {
           // Opt 20: paginate first, then hydrate only the page slice.
           // joinDocAndUri pulls documents from disk for just the page.
           searchResults = selectedPlan
@@ -145,7 +149,12 @@ function performSearch(scp) {
       }
 
       // Opt 21: calculateFacets dispatches internally based on rows/scopedCtsQuery.
-      facetResponses = calculateFacets(rows, facetRequests, scopedCtsQuery);
+      facetResponses = calculateFacets(
+        rows,
+        facetRequests,
+        scopedCtsQuery,
+        scopedCtsQueryEstimate,
+      );
     }
 
     return new SearchExecutionResult({


### PR DESCRIPTION
When able to use cts.estimate, do not perform the search or calculate facets when the estimate is zero.