### PR TITLE
Lexicon facets with CTS only search criteria are now calculated using cts.fieldValues

### DIFF
--- a/src/main/ml-modules/root/lib/search/FacetRequests.mjs
+++ b/src/main/ml-modules/root/lib/search/FacetRequests.mjs
@@ -48,6 +48,8 @@ const FacetRequests = class {
     } else {
       throw new BadRequestError(`'${facetName}' is not a configured facet.`);
     }
+
+    return this;
   }
 
   getFacetRequests() {

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -165,10 +165,6 @@ function _calculateNonSemanticFacetViaCts(
   pageLength,
   sort,
 ) {
-  console.log(
-    `Calculating non-semantic facet '${facetName}' via CTS fieldValues.`,
-  );
-
   // Require search criteria.
   if (!scopedCtsQuery) {
     throw new BadRequestError(`The facet request requires search criteria.`);

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -36,6 +36,7 @@ function calculateFacets(
   facetRequests,
   scopedCtsQuery = null,
   scopedCtsQueryEstimate = null,
+  testDispatchLogic = false,
 ) {
   if (facetRequests == null || facetRequests.length === 0) {
     return null;
@@ -43,7 +44,7 @@ function calculateFacets(
 
   const requests = facetRequests.getFacetRequests();
   if (!utils.isNonEmptyArray(requests)) {
-    return new FacetResponses({});
+    return _buildEmptyFacetResponses([]);
   }
 
   // Use the estimate when provided, but do not call cts.estimate here when
@@ -58,44 +59,44 @@ function calculateFacets(
   const start = (page - 1) * pageLength;
   const end = page * pageLength;
 
+  let docsPlan = null;
+  if (!scopedCtsQuery) {
+    const uriList = Array.isArray(rows) ? rows.map((row) => row.id) : [];
+    if (uriList.length === 0) {
+      return _buildEmptyFacetResponses(requests);
+    }
+    if (!testDispatchLogic) {
+      docsPlan = op.fromSearch(cts.documentQuery(uriList));
+    }
+  }
+
   const facets = {};
   requests.forEach((request) => {
     const facetName = request?.name;
     const isSemantic = isSemanticFacet(facetName);
+    let dispatchPath;
 
     if (isSemantic && scopedCtsQuery) {
       // Path 1: CTS enumerate + estimate.
-      facets[facetName] = _calculateSemanticFacetViaCts(
-        facetName,
-        scopedCtsQuery,
-        start,
-        end,
-      );
+      facets[facetName] = testDispatchLogic
+        ? 'semanticFacetViaCts'
+        : _calculateSemanticFacetViaCts(facetName, scopedCtsQuery, start, end);
     } else if (!isSemantic && scopedCtsQuery) {
       // Path 2: cts.fieldValues
-      facets[facetName] = _calculateNonSemanticFacetViaCts(
-        facetName,
-        scopedCtsQuery,
-        page,
-        pageLength,
-        request?.sort,
-      );
+      facets[facetName] = testDispatchLogic
+        ? 'nonSemanticFacetViaCts'
+        : _calculateNonSemanticFacetViaCts(
+            facetName,
+            scopedCtsQuery,
+            page,
+            pageLength,
+            request?.sort,
+          );
     } else {
       // Path 3: Full materialization of search results given to Optic.
-
-      // Extract URIs from materialized rows.
-      let uriList = rows.map((row) => row.id);
-      if (uriList.length === 0) {
-        return _buildEmptyFacetResponses(requests);
-      }
-
-      facets[facetName] = _calculateFacetViaOptic(
-        facetName,
-        op.fromSearch(cts.documentQuery(uriList)),
-        request,
-        start,
-        end,
-      );
+      facets[facetName] = testDispatchLogic
+        ? 'facetViaOptic'
+        : _calculateFacetViaOptic(facetName, docsPlan, request, start, end);
     }
   });
 

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -72,7 +72,6 @@ function calculateFacets(
   requests.forEach((request) => {
     const facetName = request?.name;
     const isSemantic = isSemanticFacet(facetName);
-    let dispatchPath;
 
     if (isSemantic && scopedCtsQuery) {
       // Path 1: CTS enumerate + estimate.

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -65,9 +65,7 @@ function calculateFacets(
     if (uriList.length === 0) {
       return _buildEmptyFacetResponses(requests);
     }
-    if (!testDispatchLogic) {
-      docsPlan = op.fromSearch(cts.documentQuery(uriList));
-    }
+    docsPlan = op.fromSearch(cts.documentQuery(uriList));
   }
 
   const facets = {};

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -15,6 +15,7 @@ import { isSemanticFacet } from '../facetsLib.mjs';
 import { convertSecondsToDateStr } from '../../utils/dateUtils.mjs';
 import * as utils from '../../utils/utils.mjs';
 import {
+  BadRequestError,
   InternalServerError,
   InvalidSearchRequestError,
 } from '../errorClasses.mjs';
@@ -52,15 +53,6 @@ function calculateFacets(
     return _buildEmptyFacetResponses(requests);
   }
 
-  // Path 3 setup: extract URIs from materialized rows.
-  let uriList = null;
-  if (!scopedCtsQuery) {
-    uriList = rows.map((row) => row.id);
-    if (!utils.isNonEmptyArray(uriList)) {
-      return _buildEmptyFacetResponses(requests);
-    }
-  }
-
   const page = facetRequests.getPage() ?? 1;
   const pageLength = facetRequests.getPageLength() ?? 20;
   const start = (page - 1) * pageLength;
@@ -69,8 +61,9 @@ function calculateFacets(
   const facets = {};
   requests.forEach((request) => {
     const facetName = request?.name;
+    const isSemantic = isSemanticFacet(facetName);
 
-    if (isSemanticFacet(facetName) && scopedCtsQuery) {
+    if (isSemantic && scopedCtsQuery) {
       // Path 1: CTS enumerate + estimate.
       facets[facetName] = _calculateSemanticFacetViaCts(
         facetName,
@@ -78,15 +71,27 @@ function calculateFacets(
         start,
         end,
       );
+    } else if (!isSemantic && scopedCtsQuery) {
+      // Path 2: cts.fieldValues
+      facets[facetName] = _calculateNonSemanticFacetViaCts(
+        facetName,
+        scopedCtsQuery,
+        page,
+        pageLength,
+        request?.sort,
+      );
     } else {
-      // Path 2 or 3: Optic join.
-      const docsPlan = scopedCtsQuery
-        ? op.fromSearch(scopedCtsQuery)
-        : op.fromSearch(cts.documentQuery(uriList));
+      // Path 3: Full materialization of search results given to Optic.
+
+      // Extract URIs from materialized rows.
+      let uriList = rows.map((row) => row.id);
+      if (uriList.length === 0) {
+        return _buildEmptyFacetResponses(requests);
+      }
 
       facets[facetName] = _calculateFacetViaOptic(
         facetName,
-        docsPlan,
+        op.fromSearch(cts.documentQuery(uriList)),
         request,
         start,
         end,
@@ -152,7 +157,61 @@ function _calculateSemanticFacetViaCts(facetName, scopedCtsQuery, start, end) {
   };
 }
 
-// Path 2 and 3: Optic-based facet computation (semantic and non-semantic).
+// Path 2: CTS-native non-semantic facet computation.
+function _calculateNonSemanticFacetViaCts(
+  facetName,
+  scopedCtsQuery,
+  page,
+  pageLength,
+  sort,
+) {
+  console.log(
+    `Calculating non-semantic facet '${facetName}' via CTS fieldValues.`,
+  );
+
+  // Require search criteria.
+  if (!scopedCtsQuery) {
+    throw new BadRequestError(`The facet request requires search criteria.`);
+  }
+
+  const fieldValuesOptions = ['lazy', 'score-zero'];
+  switch (sort) {
+    case 'asc':
+      fieldValuesOptions.push('ascending');
+      break;
+    case 'desc':
+      fieldValuesOptions.push('descending');
+      break;
+    default:
+      fieldValuesOptions.push('frequency-order');
+  }
+
+  const facetConfig = FACETS_CONFIG[facetName];
+  const sequence = cts.fieldValues(
+    facetConfig.indexReference,
+    null,
+    fieldValuesOptions,
+    scopedCtsQuery,
+  );
+
+  const isDateFacet = facetName.endsWith('Date');
+  return {
+    totalItems: fn.count(sequence),
+    facetValues: fn
+      .subsequence(
+        sequence,
+        utils.getStartingPaginationIndexForSubsequence(page, pageLength),
+        pageLength,
+      )
+      .toArray()
+      .map((value) => ({
+        value: isDateFacet ? convertSecondsToDateStr(value) : value,
+        count: cts.frequency(value),
+      })),
+  };
+}
+
+// Path 3: Optic-based facet computation (semantic and non-semantic).
 function _calculateFacetViaOptic(facetName, docsPlan, request, start, end) {
   let facetSourcePlan = docsPlan;
 

--- a/src/main/ml-modules/root/lib/search/calculateFacets.mjs
+++ b/src/main/ml-modules/root/lib/search/calculateFacets.mjs
@@ -30,7 +30,7 @@ const SEMANTIC_VALUE_LIMIT = 100;
 //   - Non-semantic facets use op.fromSearch(scopedCtsQuery) (Path 2).
 // When scopedCtsQuery is null (non-foldable query):
 //   - All facets use op.fromSearch(cts.documentQuery(uriList)) (Path 3).
-//   - rows must be non-null.
+//   - The only path that uses rows.
 function calculateFacets(
   rows,
   facetRequests,

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0822 calculateFacets-dispatchPaths.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0822 calculateFacets-dispatchPaths.mjs
@@ -9,7 +9,8 @@ console.log(`${LIB}: starting.`);
 let assertions = [];
 
 function extractDispatchResult(result, facetName) {
-  const facets = result.getFacets() ?? {};
+  const isFacetResponses = typeof result.getFacets === 'function';
+  const facets = isFacetResponses ? result.getFacets() : {};
   const dispatchCounts = {
     semanticFacetViaCts: 0,
     nonSemanticFacetViaCts: 0,
@@ -26,7 +27,7 @@ function extractDispatchResult(result, facetName) {
   });
 
   return {
-    isFacetResponses: true,
+    isFacetResponses,
     dispatchCounts,
   };
 }

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0822 calculateFacets-dispatchPaths.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0822 calculateFacets-dispatchPaths.mjs
@@ -1,0 +1,274 @@
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { executeScenario } from '/test/unitTestUtils.mjs';
+import { calculateFacets } from '/lib/search/engine.mjs';
+import { FacetRequests } from '/lib/search/FacetRequests.mjs';
+
+const LIB = '0822 calculateFacets-dispatchPaths.mjs';
+console.log(`${LIB}: starting.`);
+
+let assertions = [];
+
+function extractDispatchResult(result, facetName) {
+  const isFacetResponses =
+    result &&
+    typeof result.getFacet === 'function' &&
+    typeof result.getFacets === 'function';
+
+  if (isFacetResponses) {
+    const facets = result.getFacets() ?? {};
+    const dispatchCounts = {
+      semanticFacetViaCts: 0,
+      nonSemanticFacetViaCts: 0,
+      facetViaOptic: 0,
+    };
+    Object.values(facets).forEach((value) => {
+      if (value === 'semanticFacetViaCts') {
+        dispatchCounts.semanticFacetViaCts += 1;
+      } else if (value === 'nonSemanticFacetViaCts') {
+        dispatchCounts.nonSemanticFacetViaCts += 1;
+      } else if (value === 'facetViaOptic') {
+        dispatchCounts.facetViaOptic += 1;
+      }
+    });
+
+    return {
+      isFacetResponses: true,
+      dispatchCounts,
+    };
+  }
+
+  return {
+    isFacetResponses: false,
+    dispatchCounts: {
+      semanticFacetViaCts: 0,
+      nonSemanticFacetViaCts: 0,
+      facetViaOptic: 0,
+    },
+  };
+}
+
+const scenarios = [
+  {
+    name: 'Path 1: semantic facet with scopedCtsQuery uses semanticFacetViaCts',
+    input: {
+      rows: [{ id: '/test/doc/1' }],
+      facetName: 'responsibleCollections',
+      facetRequests: new FacetRequests(1, 20).addFacetRequest(
+        'item',
+        'responsibleCollections',
+      ),
+      scopedCtsQuery: cts.trueQuery(),
+    },
+    expected: {
+      error: false,
+      value: {
+        semanticFacetViaCts: 1,
+        nonSemanticFacetViaCts: 0,
+        facetViaOptic: 0,
+      },
+    },
+  },
+  {
+    name: 'Path 2: non-semantic facet with scopedCtsQuery uses nonSemanticFacetViaCts',
+    input: {
+      rows: [{ id: '/test/doc/1' }],
+      facetName: 'itemRecordType',
+      facetRequests: new FacetRequests(1, 20).addFacetRequest(
+        'item',
+        'itemRecordType',
+      ),
+      scopedCtsQuery: cts.trueQuery(),
+    },
+    expected: {
+      error: false,
+      value: {
+        semanticFacetViaCts: 0,
+        nonSemanticFacetViaCts: 1,
+        facetViaOptic: 0,
+      },
+    },
+  },
+  {
+    name: 'Path 3: no scopedCtsQuery uses facetViaOptic',
+    input: {
+      rows: [{ id: '/test/doc/1' }],
+      facetName: 'itemRecordType',
+      facetRequests: new FacetRequests(1, 20).addFacetRequest(
+        'item',
+        'itemRecordType',
+      ),
+      scopedCtsQuery: null,
+    },
+    expected: {
+      error: false,
+      value: {
+        semanticFacetViaCts: 0,
+        nonSemanticFacetViaCts: 0,
+        facetViaOptic: 1,
+      },
+    },
+  },
+  {
+    name: 'No scopedCtsQuery + empty rows returns empty facet response and no dispatch call',
+    input: {
+      rows: [],
+      facetName: 'itemRecordType',
+      facetRequests: new FacetRequests(1, 20).addFacetRequest(
+        'item',
+        'itemRecordType',
+      ),
+      scopedCtsQuery: null,
+    },
+    expected: {
+      error: false,
+      value: {
+        semanticFacetViaCts: 0,
+        nonSemanticFacetViaCts: 0,
+        facetViaOptic: 0,
+      },
+    },
+  },
+  {
+    name: 'Single request with mixed facets yields semantic=2 and nonSemantic=2',
+    input: {
+      rows: [{ id: '/test/doc/1' }],
+      facetName: 'responsibleCollections',
+      facetRequests: new FacetRequests(1, 20)
+        .addFacetRequest('item', 'responsibleCollections')
+        .addFacetRequest('item', 'responsibleUnits')
+        .addFacetRequest('item', 'itemRecordType')
+        .addFacetRequest('item', 'itemHasDigitalImage'),
+      scopedCtsQuery: cts.trueQuery(),
+    },
+    expected: {
+      error: false,
+      value: {
+        semanticFacetViaCts: 2,
+        nonSemanticFacetViaCts: 2,
+        facetViaOptic: 0,
+      },
+    },
+  },
+  {
+    name: 'Semantic counter is 2 for multi-facet CTS semantic request',
+    input: {
+      rows: [{ id: '/test/doc/1' }],
+      facetName: 'responsibleCollections',
+      facetRequests: new FacetRequests(1, 20)
+        .addFacetRequest('item', 'responsibleCollections')
+        .addFacetRequest('item', 'responsibleUnits'),
+      scopedCtsQuery: cts.trueQuery(),
+    },
+    expected: {
+      error: false,
+      value: {
+        semanticFacetViaCts: 2,
+        nonSemanticFacetViaCts: 0,
+        facetViaOptic: 0,
+      },
+    },
+  },
+  {
+    name: 'Non-semantic counter is 2 for multi-facet CTS request',
+    input: {
+      rows: [{ id: '/test/doc/1' }],
+      facetName: 'itemRecordType',
+      facetRequests: new FacetRequests(1, 20)
+        .addFacetRequest('item', 'itemRecordType')
+        .addFacetRequest('item', 'itemHasDigitalImage'),
+      scopedCtsQuery: cts.trueQuery(),
+    },
+    expected: {
+      error: false,
+      value: {
+        semanticFacetViaCts: 0,
+        nonSemanticFacetViaCts: 2,
+        facetViaOptic: 0,
+      },
+    },
+  },
+  {
+    name: 'Optic counter is 2 for multi-facet non-CTS request',
+    input: {
+      rows: [{ id: '/test/doc/1' }],
+      facetName: 'itemRecordType',
+      facetRequests: new FacetRequests(1, 20)
+        .addFacetRequest('item', 'itemRecordType')
+        .addFacetRequest('item', 'itemHasDigitalImage'),
+      scopedCtsQuery: null,
+    },
+    expected: {
+      error: false,
+      value: {
+        semanticFacetViaCts: 0,
+        nonSemanticFacetViaCts: 0,
+        facetViaOptic: 2,
+      },
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  const zeroArityFun = () => {
+    const dispatchesOrFacetResponses = calculateFacets(
+      scenario.input.rows,
+      scenario.input.facetRequests,
+      scenario.input.scopedCtsQuery,
+      null,
+      true,
+    );
+
+    return extractDispatchResult(
+      dispatchesOrFacetResponses,
+      scenario.input.facetName,
+    );
+  };
+
+  const scenarioResults = executeScenario(scenario, zeroArityFun);
+
+  if (scenarioResults.applyErrorNotExpectedAssertions) {
+    const actual = scenarioResults.actualValue;
+
+    assertions.push(
+      testHelperProxy.assertTrue(
+        actual.isFacetResponses === true,
+        `Scenario '${scenario.name}' should return FacetResponses.`,
+      ),
+    );
+
+    assertions.push(
+      testHelperProxy.assertEqual(
+        scenario.expected.value.semanticFacetViaCts,
+        actual.dispatchCounts.semanticFacetViaCts,
+        `Scenario '${scenario.name}' semanticFacetViaCts dispatch count`,
+      ),
+    );
+
+    assertions.push(
+      testHelperProxy.assertEqual(
+        scenario.expected.value.nonSemanticFacetViaCts,
+        actual.dispatchCounts.nonSemanticFacetViaCts,
+        `Scenario '${scenario.name}' nonSemanticFacetViaCts dispatch count`,
+      ),
+    );
+
+    assertions.push(
+      testHelperProxy.assertEqual(
+        scenario.expected.value.facetViaOptic,
+        actual.dispatchCounts.facetViaOptic,
+        `Scenario '${scenario.name}' facetViaOptic dispatch count`,
+      ),
+    );
+  }
+
+  if (scenarioResults.assertions.length > 0) {
+    assertions = assertions.concat(scenarioResults.assertions);
+  }
+}
+
+console.log(
+  `${LIB}: completed ${assertions.length} assertions from ${scenarios.length} scenarios.`,
+);
+
+assertions;
+export default assertions;

--- a/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0822 calculateFacets-dispatchPaths.mjs
+++ b/src/test/ml-modules/root/test/suites/searchCriteriaProcessorTests/0822 calculateFacets-dispatchPaths.mjs
@@ -9,41 +9,25 @@ console.log(`${LIB}: starting.`);
 let assertions = [];
 
 function extractDispatchResult(result, facetName) {
-  const isFacetResponses =
-    result &&
-    typeof result.getFacet === 'function' &&
-    typeof result.getFacets === 'function';
-
-  if (isFacetResponses) {
-    const facets = result.getFacets() ?? {};
-    const dispatchCounts = {
-      semanticFacetViaCts: 0,
-      nonSemanticFacetViaCts: 0,
-      facetViaOptic: 0,
-    };
-    Object.values(facets).forEach((value) => {
-      if (value === 'semanticFacetViaCts') {
-        dispatchCounts.semanticFacetViaCts += 1;
-      } else if (value === 'nonSemanticFacetViaCts') {
-        dispatchCounts.nonSemanticFacetViaCts += 1;
-      } else if (value === 'facetViaOptic') {
-        dispatchCounts.facetViaOptic += 1;
-      }
-    });
-
-    return {
-      isFacetResponses: true,
-      dispatchCounts,
-    };
-  }
+  const facets = result.getFacets() ?? {};
+  const dispatchCounts = {
+    semanticFacetViaCts: 0,
+    nonSemanticFacetViaCts: 0,
+    facetViaOptic: 0,
+  };
+  Object.values(facets).forEach((value) => {
+    if (value === 'semanticFacetViaCts') {
+      dispatchCounts.semanticFacetViaCts += 1;
+    } else if (value === 'nonSemanticFacetViaCts') {
+      dispatchCounts.nonSemanticFacetViaCts += 1;
+    } else if (value === 'facetViaOptic') {
+      dispatchCounts.facetViaOptic += 1;
+    }
+  });
 
   return {
-    isFacetResponses: false,
-    dispatchCounts: {
-      semanticFacetViaCts: 0,
-      nonSemanticFacetViaCts: 0,
-      facetViaOptic: 0,
-    },
+    isFacetResponses: true,
+    dispatchCounts,
   };
 }
 


### PR DESCRIPTION
Bypasses the Optic API.  Significantly faster for large results sets; e.g.:

<img width="776" height="211" alt="image" src="https://github.com/user-attachments/assets/67df8ca5-7917-4be0-a857-704f30fbf61f" />
