### PR TITLE
Deep freeze and deep copy related list configs

### DIFF
--- a/docs/lux-search-engine-lessons.md
+++ b/docs/lux-search-engine-lessons.md
@@ -191,12 +191,15 @@ This is a copy of an LLM memory file, which augments optic-lessons.md
 - Each file exports `assertions` (`export default assertions;`) — an array of assertion results.
 - Use the **scenarios array pattern**: define a `scenarios` array where each element has `{ name, input, expected }`. Iterate scenarios calling `executeScenario(scenario, zeroArityFun)` for each.
 - **`input`**: shape is catered to the function under test. Contains whatever arguments/state the function needs. Keep it direct — mirror the function's parameters rather than inventing a dispatch mechanism.
+- **Do NOT branch on `scenario.name`** (e.g., `scenario.name.includes('frozen')`). Use boolean or enum properties on `scenario.input` to control behavior (e.g., `scenario.input.makeDeepCopy = true`). The scenario name is for human readability only.
 - **`expected`**: standard properties handled by `executeScenario`:
   - `expected.error` (boolean): whether the function should throw.
-  - `expected.errorMessage` (string): if `error: true`, the thrown message must include this substring.
-  - `expected.stackToInclude` (string): if `error: true`, the stack trace must include this substring.
+  - `expected.stackToInclude` (string): if `error: true`, the stack trace must include this substring. This is checked by `executeScenario` — there is no `expected.errorMessage` property.
   - `expected.value`: the exact return value to assert against via `assertEqual`. Used for direct value comparison — not derived booleans.
+  - `expected.selectContains` (string[]): when the actual return value is a string, asserts that at least one `.select()` call contains each column name.
+  - `expected.orderByContains` (string[]): when the actual return value is a string, asserts that at least one `.orderBy()` call contains each column name.
 - Beyond these standard properties, `expected` can include any custom fields for function-specific assertions applied after `executeScenario` returns.
 - `executeScenario` wraps the zero-arity function call, catches errors, and returns `{ actualValue, applyErrorNotExpectedAssertions, applyErrorExpectedAssertions }` — use these flags to gate subsequent assertions.
+- **Use `executeScenario` by default**, even when the function under test is not the direct return value. Call the function inside `zeroArityFun`, then return a value to assert against. This ensures unexpected exceptions are caught and reported properly instead of blowing up the test file. If you believe a test warrants skipping `executeScenario`, ask for permission first and state why.
 - Integration tests (e.g., 0600) hit the deployed engine with real search criteria. Unit tests (e.g., 0601–0603) import functions directly and test with synthetic inputs.
 - Assertions use `testHelperProxy.assertEqual(expected, actual, message)`, `assertTrue`, `assertFalse`.

--- a/src/main/ml-modules/root/lib/relatedListsLib.mjs
+++ b/src/main/ml-modules/root/lib/relatedListsLib.mjs
@@ -145,7 +145,9 @@ function getRelatedList({
     const urisByRelation = {};
     const relationToScope = {}; // And the scopes
     const relationToCriteria = {}; // And the resolved search criteria
-    const searchConfigs = sortByPriority(relatedListConfig.searchConfigs);
+    const searchConfigs = sortByPriority(
+      utils.getDeepCopy(relatedListConfig.searchConfigs),
+    );
     // Old school loop to give this boomer confidence the order is honored.
     for (let i = 0; i < searchConfigs.length; i++) {
       const searchConfig = searchConfigs[i];

--- a/src/main/ml-modules/root/runDuringDeployment/generateRelatedListsConfig.mjs
+++ b/src/main/ml-modules/root/runDuringDeployment/generateRelatedListsConfig.mjs
@@ -304,8 +304,9 @@ function constructModuleNode(relatedListsConfig) {
  */
 import { getCurrentUserUnitName } from '../lib/securityLib.mjs';
 import { BadRequestError } from '../lib/errorClasses.mjs';
-  
-const RELATED_LISTS_CONFIG = ${JSON.stringify(relatedListsConfig)};
+import { deepFreeze } from '../utils/utils.mjs';
+
+const RELATED_LISTS_CONFIG = deepFreeze(${JSON.stringify(relatedListsConfig)});
 
 function getRelatedListKeys() {
   const relatedListsConfig = _getRelatedListsConfig(true);

--- a/src/main/ml-modules/root/utils/utils.mjs
+++ b/src/main/ml-modules/root/utils/utils.mjs
@@ -452,6 +452,16 @@ function getDeepCopy(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
+function deepFreeze(obj) {
+  Object.freeze(obj);
+  Object.keys(obj).forEach((key) => {
+    if (typeof obj[key] === 'object' && obj[key] !== null && !Object.isFrozen(obj[key])) {
+      deepFreeze(obj[key]);
+    }
+  });
+  return obj;
+}
+
 // Splits the string by comma.
 // Odd entries are role names.
 // Even entries are capability names.
@@ -649,6 +659,7 @@ export {
   formatString,
   getArrayDiff,
   getArrayOverlap,
+  deepFreeze,
   getDeepCopy,
   getDocFromModulesDatabase,
   getDocPermissionsFromString,

--- a/src/test/ml-modules/root/test/suites/relatedListTests/0100 getRelatedListConfig.mjs
+++ b/src/test/ml-modules/root/test/suites/relatedListTests/0100 getRelatedListConfig.mjs
@@ -1,0 +1,69 @@
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { executeScenario } from '/test/unitTestUtils.mjs';
+import { getRelatedListConfig } from '/config/relatedListsConfig.mjs';
+import { getDeepCopy } from '/utils/utils.mjs';
+
+const LIB = '0100 getRelatedListConfig.mjs';
+console.log(`${LIB}: starting.`);
+
+let assertions = [];
+
+const scenarios = [
+  {
+    name: 'Modification of frozen config throws TypeError',
+    input: {
+      scopeName: 'agent',
+      relatedListName: 'relatedToAgent',
+      makeDeepCopy: false,
+    },
+    expected: {
+      error: true,
+      stackToInclude: 'TypeError',
+    },
+  },
+  {
+    name: 'Modification of deep copy does not throw',
+    input: {
+      scopeName: 'agent',
+      relatedListName: 'relatedToAgent',
+      makeDeepCopy: true,
+    },
+    expected: {
+      error: false,
+    },
+  },
+];
+
+for (const scenario of scenarios) {
+  const zeroArityFun = () => {
+    const config = getRelatedListConfig(
+      scenario.input.scopeName,
+      scenario.input.relatedListName,
+    );
+    const target = scenario.input.makeDeepCopy ? getDeepCopy(config) : config;
+    // Attempt to mutate a nested property value.
+    target.searchConfigs[0].criteria[
+      Object.keys(target.searchConfigs[0].criteria)[0]
+    ] = 'tampered';
+    return target.searchConfigs[0].criteria[
+      Object.keys(target.searchConfigs[0].criteria)[0]
+    ];
+  };
+
+  const scenarioResults = executeScenario(scenario, zeroArityFun);
+  assertions = assertions.concat(scenarioResults.assertions);
+
+  if (scenarioResults.applyErrorNotExpectedAssertions) {
+    assertions.push(
+      testHelperProxy.assertEqual(
+        'tampered',
+        scenarioResults.actualValue,
+        `Scenario '${scenario.name}': deep copy should be mutable.`,
+      ),
+    );
+  }
+}
+
+console.log(`${LIB}: finished.`);
+assertions;
+export default assertions;

--- a/src/test/ml-modules/root/test/suites/relatedListTests/0200 getRelatedList.mjs
+++ b/src/test/ml-modules/root/test/suites/relatedListTests/0200 getRelatedList.mjs
@@ -1,0 +1,93 @@
+import { testHelperProxy } from '/test/test-helper.mjs';
+import { executeScenario } from '/test/unitTestUtils.mjs';
+import { getRelatedListConfig } from '/config/relatedListsConfig.mjs';
+import { getRelatedList } from '/lib/relatedListsLib.mjs';
+import { TOKEN_RUNTIME_PARAM } from '/lib/appConstants.mjs';
+
+const LIB = '0200 getRelatedList.mjs';
+console.log(`${LIB}: starting.`);
+
+let assertions = [];
+
+const scenarios = [
+  {
+    name: 'Config not mutated after first getRelatedList call',
+    input: {
+      scopeName: 'agent',
+      relatedListName: 'relatedToAgent',
+      uri: 'https://lux.collections.yale.edu/data/person/does-not-exist',
+    },
+    expected: { error: false },
+  },
+  {
+    name: 'Config not mutated after second call with different URI',
+    input: {
+      scopeName: 'agent',
+      relatedListName: 'relatedToAgent',
+      uri: 'https://lux.collections.yale.edu/data/person/also-does-not-exist',
+    },
+    expected: { error: false },
+  },
+];
+
+// Snapshot the config before any calls.
+const configSnapshot = JSON.stringify(
+  getRelatedListConfig(
+    scenarios[0].input.scopeName,
+    scenarios[0].input.relatedListName,
+  ),
+);
+
+for (const scenario of scenarios) {
+  const zeroArityFun = () => {
+    getRelatedList({
+      searchScopeName: scenario.input.scopeName,
+      relatedListName: scenario.input.relatedListName,
+      uri: scenario.input.uri,
+      page: 1,
+      pageLength: 25,
+      filterResults: false,
+      relationshipsPerRelation: 5,
+      onlyCheckForOneRelatedItem: false,
+    });
+    return JSON.stringify(
+      getRelatedListConfig(
+        scenario.input.scopeName,
+        scenario.input.relatedListName,
+      ),
+    );
+  };
+
+  const scenarioResults = executeScenario(scenario, zeroArityFun);
+  assertions = assertions.concat(scenarioResults.assertions);
+
+  if (scenarioResults.applyErrorNotExpectedAssertions) {
+    const configAfter = scenarioResults.actualValue;
+
+    assertions.push(
+      testHelperProxy.assertEqual(
+        configSnapshot,
+        configAfter,
+        `Scenario '${scenario.name}': config must match the pre-call snapshot.`,
+      ),
+    );
+
+    assertions.push(
+      testHelperProxy.assertTrue(
+        configAfter.includes(TOKEN_RUNTIME_PARAM),
+        `Scenario '${scenario.name}': config must still contain '${TOKEN_RUNTIME_PARAM}' tokens.`,
+      ),
+    );
+
+    assertions.push(
+      testHelperProxy.assertFalse(
+        configAfter.includes(scenario.input.uri),
+        `Scenario '${scenario.name}': config must not contain the request URI.`,
+      ),
+    );
+  }
+}
+
+console.log(`${LIB}: finished.`);
+assertions;
+export default assertions;

--- a/src/test/ml-modules/root/test/unitTestUtils.mjs
+++ b/src/test/ml-modules/root/test/unitTestUtils.mjs
@@ -21,6 +21,10 @@ const sec = require('/MarkLogic/security.xqy');
  *       applicable when the function being tested returns an object, which this function then creates a
  *       node out of and applies the assertions to.  There are three types of assertions: equality, xpath,
  *       and function.  See the implementation for examples and utilized properties of each.
+ *    expected.selectContains: Optional array of column name strings.  When the actual return value is a
+ *       string (e.g., plan source), asserts that at least one .select() call contains each column name.
+ *    expected.orderByContains: Optional array of column name strings.  When the actual return value is a
+ *       string, asserts that at least one .orderBy() call contains each column name.
  * @param {Function} zeroArityFun is the function to be tested.  It must be zero arity.
  * @param {Object} invokeFunOptions is the options to be passed to the xdmp.invokeFunction call.
  * @returns object with the following top-level properties: actualValue, applyErrorNotExpectedAssertions,


### PR DESCRIPTION
During the related list's serialized request performance test, we were noticing seemingly random results for some requests.  We could not reproduce outside of this context; in Postman, Optic was returning the same results as CTS.

We then modified utils.replaceMatchingPropertyValues to throw an exception if it didn't find the value to replace.  That function is only called by `getRelatedList`, which passes in `@@RUNTIME_PARAM@@` as the value to replace.  getRelatedList is replacing that value in a single triple search with the IRI the request is for:

```javascript
          {
            relationKey: 'created-aboutAgent',
            relationScope: 'work',
            criteria: { created: { aboutAgent: { iri: '@@RUNTIME_PARAM@@' } } },
          },
```

The exception was thrown for ~10% of the requests, indicating related list configuration mutation was crossing transactions (back-to-back Data Service calls):

> 2026-07-16 15:28:40.972 Info: [Event:id=LuxError] {"statusCode":500,"status":"JS-JAVASCRIPT","message":"Error running JavaScript request"}
> 2026-07-16 15:28:40.972 Notice: JS-JAVASCRIPT: throw new Error( -- Error running JavaScript request: Error: replaceMatchingPropertyValues found zero occurrences of '@@RUNTIME_PARAM@@' to replace with 'https://lux.collections.yale.edu/data/person/f6e8b38a-756a-42dc-8912-481348b6a801'. Object received: {"createdHere":{"aboutAgent":{"iri":"https://lux.collections.yale.edu/data/person/37812d04-47d6-4866-8f5d-cd2b090ad834"}}}
> 2026-07-16 15:28:40.972 Notice:+in ../utils/utils.mjs, at 290:12, in replaceMatchingPropertyValues() [javascript]
> 2026-07-16 15:28:40.972 Notice:+in ../../lib/relatedListsLib.mjs, at 154:30, in getRelatedList() [javascript]

Fix was for getRelatedList to create a deep copy of the configuration it needed.  Took this a step further by freezing the entire related list configuration.

